### PR TITLE
Fix/support ruby 2.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,7 +16,6 @@ engines:
     enabled: true
   rubocop:
     enabled: true
-    target_ruby_version: 2.3.1
 ratings:
   paths:
   - "**.css"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.1.0
+  TargetRubyVersion: 2.1
 
 #################### Lint ################################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.1.0
 
 #################### Lint ################################
 

--- a/docs/Helium.html
+++ b/docs/Helium.html
@@ -121,7 +121,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium.html
+++ b/docs/Helium.html
@@ -121,7 +121,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client.html
+++ b/docs/Helium/Client.html
@@ -195,7 +195,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(api_key:, debug: false)  &#x21d2; Client </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; Client </a>
     
 
     
@@ -325,7 +325,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(api_key:, debug: false)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Client (class)">Client</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Client (class)">Client</a></span></tt> 
   
 
   
@@ -355,9 +355,9 @@
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/client.rb', line 20</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>api_key:</span><span class='comma'>,</span> <span class='label'>debug:</span> <span class='kw'>false</span><span class='rparen'>)</span>
-  <span class='ivar'>@api_key</span> <span class='op'>=</span> <span class='id identifier rubyid_api_key'>api_key</span>
-  <span class='ivar'>@debug</span> <span class='op'>=</span> <span class='id identifier rubyid_debug'>debug</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='ivar'>@api_key</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:api_key</span><span class='rparen'>)</span>
+  <span class='ivar'>@debug</span>   <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:debug</span><span class='comma'>,</span> <span class='kw'>false</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -505,7 +505,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client.html
+++ b/docs/Helium/Client.html
@@ -505,7 +505,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:36 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Elements.html
+++ b/docs/Helium/Client/Elements.html
@@ -223,7 +223,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Elements.html
+++ b/docs/Helium/Client/Elements.html
@@ -223,7 +223,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Http.html
+++ b/docs/Helium/Client/Http.html
@@ -159,7 +159,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#get-instance_method" title="#get (instance method)">#<strong>get</strong>(path = nil, url: nil, params: {})  &#x21d2; Object </a>
+      <a href="#get-instance_method" title="#get (instance method)">#<strong>get</strong>(path, opts = {})  &#x21d2; Object </a>
     
 
     
@@ -181,7 +181,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#paginated_get-instance_method" title="#paginated_get (instance method)">#<strong>paginated_get</strong>(path, klass:, params: {})  &#x21d2; Object </a>
+      <a href="#paginated_get-instance_method" title="#paginated_get (instance method)">#<strong>paginated_get</strong>(path, opts = {})  &#x21d2; Object </a>
     
 
     
@@ -203,7 +203,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#patch-instance_method" title="#patch (instance method)">#<strong>patch</strong>(path, body: {})  &#x21d2; Object </a>
+      <a href="#patch-instance_method" title="#patch (instance method)">#<strong>patch</strong>(path, opts = {})  &#x21d2; Object </a>
     
 
     
@@ -225,7 +225,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#post-instance_method" title="#post (instance method)">#<strong>post</strong>(path, body: {})  &#x21d2; Object </a>
+      <a href="#post-instance_method" title="#post (instance method)">#<strong>post</strong>(path, opts = {})  &#x21d2; Object </a>
     
 
     
@@ -268,14 +268,14 @@
       <pre class="lines">
 
 
-33
-34
-35
-36
-37</pre>
+42
+43
+44
+45
+46</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 33</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 42</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_delete'>delete</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:delete</span><span class='rparen'>)</span>
@@ -290,7 +290,7 @@
       <div class="method_details ">
   <h3 class="signature " id="get-instance_method">
   
-    #<strong>get</strong>(path = nil, url: nil, params: {})  &#x21d2; <tt>Object</tt> 
+    #<strong>get</strong>(path, opts = {})  &#x21d2; <tt>Object</tt> 
   
 
   
@@ -305,13 +305,17 @@
 14
 15
 16
-17</pre>
+17
+18
+19</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 14</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_get'>get</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>url:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>url:</span> <span class='id identifier rubyid_url'>url</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:get</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_get'>get</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+
+  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:get</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -322,7 +326,7 @@
       <div class="method_details ">
   <h3 class="signature " id="paginated_get-instance_method">
   
-    #<strong>paginated_get</strong>(path, klass:, params: {})  &#x21d2; <tt>Object</tt> 
+    #<strong>paginated_get</strong>(path, opts = {})  &#x21d2; <tt>Object</tt> 
   
 
   
@@ -334,14 +338,20 @@
       <pre class="lines">
 
 
-19
-20
-21</pre>
+21
+22
+23
+24
+25
+26</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 19</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 21</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_paginated_get'>paginated_get</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>klass:</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_paginated_get'>paginated_get</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_klass'>klass</span>  <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:klass</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+
   <span class='const'>Cursor</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='kw'>self</span><span class='comma'>,</span> <span class='label'>path:</span> <span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>klass:</span> <span class='id identifier rubyid_klass'>klass</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -352,7 +362,43 @@
       <div class="method_details ">
   <h3 class="signature " id="patch-instance_method">
   
-    #<strong>patch</strong>(path, body: {})  &#x21d2; <tt>Object</tt> 
+    #<strong>patch</strong>(path, opts = {})  &#x21d2; <tt>Object</tt> 
+  
+
+  
+
+  
+</h3><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+35
+36
+37
+38
+39
+40</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 35</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_patch'>patch</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:body</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+
+  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:patch</span><span class='comma'>,</span> <span class='label'>body:</span> <span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="post-instance_method">
+  
+    #<strong>post</strong>(path, opts = {})  &#x21d2; <tt>Object</tt> 
   
 
   
@@ -367,44 +413,16 @@
 28
 29
 30
-31</pre>
+31
+32
+33</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 28</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_patch'>patch</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>body:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:patch</span><span class='comma'>,</span> <span class='label'>body:</span> <span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
-      <div class="method_details ">
-  <h3 class="signature " id="post-instance_method">
-  
-    #<strong>post</strong>(path, body: {})  &#x21d2; <tt>Object</tt> 
-  
+<span class='kw'>def</span> <span class='id identifier rubyid_post'>post</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:body</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
 
-  
-
-  
-</h3><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-23
-24
-25
-26</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 23</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_post'>post</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>body:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:post</span><span class='comma'>,</span> <span class='label'>body:</span> <span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -418,7 +436,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Http.html
+++ b/docs/Helium/Client/Http.html
@@ -268,18 +268,16 @@
       <pre class="lines">
 
 
-42
-43
-44
-45
-46</pre>
+33
+34
+35
+36</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 42</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 33</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_delete'>delete</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:delete</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='symbol'>:delete</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_code'>code</span> <span class='op'>==</span> <span class='int'>204</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -304,19 +302,13 @@
 
 14
 15
-16
-17
-18
-19</pre>
+16</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 14</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_get'>get</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-
-  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:get</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='symbol'>:get</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -338,15 +330,15 @@
       <pre class="lines">
 
 
+18
+19
+20
 21
 22
-23
-24
-25
-26</pre>
+23</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 21</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 18</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_paginated_get'>paginated_get</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_klass'>klass</span>  <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:klass</span><span class='rparen'>)</span>
@@ -374,21 +366,15 @@
       <pre class="lines">
 
 
-35
-36
-37
-38
-39
-40</pre>
+29
+30
+31</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 35</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 29</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_patch'>patch</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:body</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-
-  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:patch</span><span class='comma'>,</span> <span class='label'>body:</span> <span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='symbol'>:patch</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -410,21 +396,15 @@
       <pre class="lines">
 
 
-28
-29
-30
-31
-32
-33</pre>
+25
+26
+27</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 28</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/client/http.rb', line 25</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_post'>post</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:body</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-
-  <span class='id identifier rubyid_request'>request</span> <span class='op'>=</span> <span class='id identifier rubyid_generate_request'>generate_request</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>method:</span> <span class='symbol'>:post</span><span class='comma'>,</span> <span class='label'>body:</span> <span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_request'>request</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_run'>run</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='symbol'>:post</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -436,7 +416,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Labels.html
+++ b/docs/Helium/Client/Labels.html
@@ -196,7 +196,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#update_label_sensors-instance_method" title="#update_label_sensors (instance method)">#<strong>update_label_sensors</strong>(label, sensors: [])  &#x21d2; Object </a>
+      <a href="#update_label_sensors-instance_method" title="#update_label_sensors (instance method)">#<strong>update_label_sensors</strong>(label, opts = {})  &#x21d2; Object </a>
     
 
     
@@ -363,7 +363,7 @@
       <div class="method_details ">
   <h3 class="signature " id="update_label_sensors-instance_method">
   
-    #<strong>update_label_sensors</strong>(label, sensors: [])  &#x21d2; <tt>Object</tt> 
+    #<strong>update_label_sensors</strong>(label, opts = {})  &#x21d2; <tt>Object</tt> 
   
 
   
@@ -401,12 +401,16 @@
 51
 52
 53
-54</pre>
+54
+55
+56</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/client/labels.rb', line 28</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_update_label_sensors'>update_label_sensors</span><span class='lparen'>(</span><span class='id identifier rubyid_label'>label</span><span class='comma'>,</span> <span class='label'>sensors:</span> <span class='lbracket'>[</span><span class='rbracket'>]</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_update_label_sensors'>update_label_sensors</span><span class='lparen'>(</span><span class='id identifier rubyid_label'>label</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_sensors'>sensors</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:sensors</span><span class='comma'>,</span> <span class='lbracket'>[</span><span class='rbracket'>]</span><span class='rparen'>)</span>
+
   <span class='id identifier rubyid_path'>path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/label/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_label'>label</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span><span class='embexpr_end'>}</span><span class='tstring_content'>/relationships/sensor</span><span class='tstring_end'>&quot;</span></span>
 
   <span class='id identifier rubyid_sensors'>sensors</span> <span class='op'>=</span> <span class='const'>Array</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors'>sensors</span><span class='rparen'>)</span>
@@ -443,7 +447,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Labels.html
+++ b/docs/Helium/Client/Labels.html
@@ -447,7 +447,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Organizations.html
+++ b/docs/Helium/Client/Organizations.html
@@ -241,7 +241,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Organizations.html
+++ b/docs/Helium/Client/Organizations.html
@@ -241,7 +241,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Sensors.html
+++ b/docs/Helium/Client/Sensors.html
@@ -305,7 +305,7 @@
     <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>filter[end]</span><span class='tstring_end'>&quot;</span></span>   <span class='op'>=&gt;</span> <span class='id identifier rubyid_datetime_to_iso'>datetime_to_iso</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:end_time</span><span class='comma'>,</span> <span class='kw'>nil</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='comma'>,</span>
     <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>agg[type]</span><span class='tstring_end'>&quot;</span></span>     <span class='op'>=&gt;</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:aggtype</span><span class='rparen'>)</span><span class='comma'>,</span>
     <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>agg[size]</span><span class='tstring_end'>&quot;</span></span>     <span class='op'>=&gt;</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:aggsize</span><span class='rparen'>)</span>
-  <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_delete_if'>delete_if</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_key'>key</span><span class='comma'>,</span> <span class='id identifier rubyid_value'>value</span><span class='op'>|</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='period'>.</span><span class='id identifier rubyid_empty?'>empty?</span> <span class='rbrace'>}</span>
+  <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_delete_if'>delete_if</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid__key'>_key</span><span class='comma'>,</span> <span class='id identifier rubyid_value'>value</span><span class='op'>|</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='period'>.</span><span class='id identifier rubyid_empty?'>empty?</span> <span class='rbrace'>}</span>
 
   <span class='id identifier rubyid_paginated_get'>paginated_get</span><span class='lparen'>(</span><span class='id identifier rubyid_path'>path</span><span class='comma'>,</span> <span class='label'>klass:</span> <span class='const'>Helium</span><span class='op'>::</span><span class='const'>DataPoint</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
@@ -349,7 +349,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Sensors.html
+++ b/docs/Helium/Client/Sensors.html
@@ -349,7 +349,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Users.html
+++ b/docs/Helium/Client/Users.html
@@ -175,7 +175,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Client/Users.html
+++ b/docs/Helium/Client/Users.html
@@ -175,7 +175,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Cursor.html
+++ b/docs/Helium/Cursor.html
@@ -146,7 +146,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, path:, klass:, params: {})  &#x21d2; Cursor </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; Cursor </a>
     
 
     
@@ -200,7 +200,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, path:, klass:, params: {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Cursor (class)">Cursor</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Cursor (class)">Cursor</a></span></tt> 
   
 
   
@@ -236,11 +236,11 @@
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/cursor.rb', line 5</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>path:</span><span class='comma'>,</span> <span class='label'>klass:</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='ivar'>@client</span> <span class='op'>=</span> <span class='id identifier rubyid_client'>client</span>
-  <span class='ivar'>@path</span>   <span class='op'>=</span> <span class='id identifier rubyid_path'>path</span>
-  <span class='ivar'>@klass</span>  <span class='op'>=</span> <span class='id identifier rubyid_klass'>klass</span>
-  <span class='ivar'>@params</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='ivar'>@client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='ivar'>@path</span>   <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:path</span><span class='rparen'>)</span>
+  <span class='ivar'>@klass</span>  <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:klass</span><span class='rparen'>)</span>
+  <span class='ivar'>@params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
 
   <span class='ivar'>@collection</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span>
   <span class='ivar'>@next_link</span>  <span class='op'>=</span> <span class='kw'>nil</span>
@@ -347,7 +347,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Cursor.html
+++ b/docs/Helium/Cursor.html
@@ -347,7 +347,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:36 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/DataPoint.html
+++ b/docs/Helium/DataPoint.html
@@ -395,23 +395,17 @@
 8
 9
 10
-11
-12
-13
-14</pre>
+11</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 5</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+  <span class='kw'>super</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 
-  <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
-
-  <span class='ivar'>@timestamp</span>  <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>timestamp</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@value</span>      <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>value</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@port</span>       <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>port</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@timestamp</span>  <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>timestamp</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@value</span>      <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>value</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@port</span>       <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>port</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -593,12 +587,12 @@
       <pre class="lines">
 
 
-35
-36
-37</pre>
+32
+33
+34</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 35</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 32</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_aggregate?'>aggregate?</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_max'>max</span><span class='comma'>,</span> <span class='id identifier rubyid_min'>min</span><span class='comma'>,</span> <span class='id identifier rubyid_avg'>avg</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_none?'>none?</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_agg_value'>agg_value</span><span class='op'>|</span> <span class='id identifier rubyid_agg_value'>agg_value</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span> <span class='rbrace'>}</span>
@@ -623,6 +617,9 @@
       <pre class="lines">
 
 
+36
+37
+38
 39
 40
 41
@@ -635,13 +632,10 @@
 48
 49
 50
-51
-52
-53
-54</pre>
+51</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 39</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 36</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='id identifier rubyid_j'>j</span> <span class='op'>=</span> <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -679,13 +673,13 @@
       <pre class="lines">
 
 
-30
-31
-32
-33</pre>
+27
+28
+29
+30</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 30</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 27</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_avg'>avg</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>unless</span> <span class='ivar'>@value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='const'>Hash</span><span class='rparen'>)</span>
@@ -711,13 +705,13 @@
       <pre class="lines">
 
 
-20
-21
-22
-23</pre>
+17
+18
+19
+20</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 20</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 17</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_max'>max</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>unless</span> <span class='ivar'>@value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='const'>Hash</span><span class='rparen'>)</span>
@@ -743,13 +737,13 @@
       <pre class="lines">
 
 
-25
-26
-27
-28</pre>
+22
+23
+24
+25</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 25</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 22</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_min'>min</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>unless</span> <span class='ivar'>@value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='const'>Hash</span><span class='rparen'>)</span>
@@ -765,7 +759,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:36 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/DataPoint.html
+++ b/docs/Helium/DataPoint.html
@@ -281,7 +281,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, params:)  &#x21d2; DataPoint </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; DataPoint </a>
     
 
     
@@ -367,7 +367,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, params:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::DataPoint (class)">DataPoint</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::DataPoint (class)">DataPoint</a></span></tt> 
   
 
   
@@ -395,12 +395,18 @@
 8
 9
 10
-11</pre>
+11
+12
+13
+14</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 5</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>params:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+
   <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 
   <span class='ivar'>@timestamp</span>  <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>timestamp</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
@@ -587,12 +593,12 @@
       <pre class="lines">
 
 
-32
-33
-34</pre>
+35
+36
+37</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 32</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 35</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_aggregate?'>aggregate?</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_max'>max</span><span class='comma'>,</span> <span class='id identifier rubyid_min'>min</span><span class='comma'>,</span> <span class='id identifier rubyid_avg'>avg</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_none?'>none?</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_agg_value'>agg_value</span><span class='op'>|</span> <span class='id identifier rubyid_agg_value'>agg_value</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span> <span class='rbrace'>}</span>
@@ -617,9 +623,6 @@
       <pre class="lines">
 
 
-36
-37
-38
 39
 40
 41
@@ -632,10 +635,13 @@
 48
 49
 50
-51</pre>
+51
+52
+53
+54</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 36</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 39</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='id identifier rubyid_j'>j</span> <span class='op'>=</span> <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -673,13 +679,13 @@
       <pre class="lines">
 
 
-27
-28
-29
-30</pre>
+30
+31
+32
+33</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 27</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 30</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_avg'>avg</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>unless</span> <span class='ivar'>@value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='const'>Hash</span><span class='rparen'>)</span>
@@ -705,13 +711,13 @@
       <pre class="lines">
 
 
-17
-18
-19
-20</pre>
+20
+21
+22
+23</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 17</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 20</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_max'>max</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>unless</span> <span class='ivar'>@value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='const'>Hash</span><span class='rparen'>)</span>
@@ -737,13 +743,13 @@
       <pre class="lines">
 
 
-22
-23
-24
-25</pre>
+25
+26
+27
+28</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 22</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/data_point.rb', line 25</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_min'>min</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>unless</span> <span class='ivar'>@value</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='const'>Hash</span><span class='rparen'>)</span>
@@ -759,7 +765,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Element.html
+++ b/docs/Helium/Element.html
@@ -308,23 +308,17 @@
 8
 9
 10
-11
-12
-13
-14</pre>
+11</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/element.rb', line 5</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
-  
-  <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
+  <span class='kw'>super</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 
-  <span class='ivar'>@name</span>     <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>name</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@mac</span>      <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>mac</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@versions</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>versions</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@name</span>     <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>name</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@mac</span>      <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>mac</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@versions</span> <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>versions</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -494,16 +488,16 @@
       <pre class="lines">
 
 
+14
+15
+16
 17
 18
 19
-20
-21
-22
-23</pre>
+20</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/element.rb', line 17</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/element.rb', line 14</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -522,7 +516,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:36 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Element.html
+++ b/docs/Helium/Element.html
@@ -238,7 +238,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, params:)  &#x21d2; Element </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; Element </a>
     
 
     
@@ -280,7 +280,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, params:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Element (class)">Element</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Element (class)">Element</a></span></tt> 
   
 
   
@@ -308,12 +308,18 @@
 8
 9
 10
-11</pre>
+11
+12
+13
+14</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/element.rb', line 5</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>params:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+  
   <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 
   <span class='ivar'>@name</span>     <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>name</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
@@ -488,16 +494,16 @@
       <pre class="lines">
 
 
-14
-15
-16
 17
 18
 19
-20</pre>
+20
+21
+22
+23</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/element.rb', line 14</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/element.rb', line 17</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -516,7 +522,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Label.html
+++ b/docs/Helium/Label.html
@@ -317,21 +317,15 @@
 6
 7
 8
-9
-10
-11
-12</pre>
+9</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 5</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+  <span class='kw'>super</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 
-  <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
-
-  <span class='ivar'>@name</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>name</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@name</span> <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>name</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -407,14 +401,14 @@
       <pre class="lines">
 
 
+17
+18
+19
 20
-21
-22
-23
-24</pre>
+21</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 20</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 17</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_add_sensors'>add_sensors</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_add'>sensors_to_add</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_sensors_to_add'>sensors_to_add</span> <span class='op'>=</span> <span class='const'>Array</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_add'>sensors_to_add</span><span class='rparen'>)</span>
@@ -451,14 +445,14 @@
       <pre class="lines">
 
 
+30
+31
+32
 33
-34
-35
-36
-37</pre>
+34</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 33</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 30</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -485,14 +479,14 @@
       <pre class="lines">
 
 
+23
+24
+25
 26
-27
-28
-29
-30</pre>
+27</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 26</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 23</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_remove_sensors'>remove_sensors</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_remove'>sensors_to_remove</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_sensors_to_remove'>sensors_to_remove</span> <span class='op'>=</span> <span class='const'>Array</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_remove'>sensors_to_remove</span><span class='rparen'>)</span>
@@ -530,12 +524,12 @@ we could do something like label.sensors &lt;&lt; new_sensor</p>
       <pre class="lines">
 
 
-16
-17
-18</pre>
+13
+14
+15</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 16</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 13</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_sensors'>sensors</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_label_sensors'>label_sensors</span><span class='lparen'>(</span><span class='kw'>self</span><span class='rparen'>)</span>
@@ -550,7 +544,7 @@ we could do something like label.sensors &lt;&lt; new_sensor</p>
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Label.html
+++ b/docs/Helium/Label.html
@@ -204,7 +204,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, params:)  &#x21d2; Label </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; Label </a>
     
 
     
@@ -291,7 +291,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, params:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Label (class)">Label</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Label (class)">Label</a></span></tt> 
   
 
   
@@ -317,12 +317,18 @@
 6
 7
 8
-9</pre>
+9
+10
+11
+12</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 5</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>params:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+
   <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 
   <span class='ivar'>@name</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>name</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
@@ -401,14 +407,14 @@
       <pre class="lines">
 
 
-17
-18
-19
 20
-21</pre>
+21
+22
+23
+24</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 17</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 20</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_add_sensors'>add_sensors</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_add'>sensors_to_add</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_sensors_to_add'>sensors_to_add</span> <span class='op'>=</span> <span class='const'>Array</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_add'>sensors_to_add</span><span class='rparen'>)</span>
@@ -445,14 +451,14 @@
       <pre class="lines">
 
 
-30
-31
-32
 33
-34</pre>
+34
+35
+36
+37</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 30</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 33</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -479,14 +485,14 @@
       <pre class="lines">
 
 
-23
-24
-25
 26
-27</pre>
+27
+28
+29
+30</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 23</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 26</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_remove_sensors'>remove_sensors</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_remove'>sensors_to_remove</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_sensors_to_remove'>sensors_to_remove</span> <span class='op'>=</span> <span class='const'>Array</span><span class='lparen'>(</span><span class='id identifier rubyid_sensors_to_remove'>sensors_to_remove</span><span class='rparen'>)</span>
@@ -524,12 +530,12 @@ we could do something like label.sensors &lt;&lt; new_sensor</p>
       <pre class="lines">
 
 
-13
-14
-15</pre>
+16
+17
+18</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 13</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/label.rb', line 16</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_sensors'>sensors</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_label_sensors'>label_sensors</span><span class='lparen'>(</span><span class='kw'>self</span><span class='rparen'>)</span>
@@ -544,7 +550,7 @@ we could do something like label.sensors &lt;&lt; new_sensor</p>
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Organization.html
+++ b/docs/Helium/Organization.html
@@ -301,22 +301,16 @@
 7
 8
 9
-10
-11
-12
-13</pre>
+10</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 5</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
-  
-  <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
+  <span class='kw'>super</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 
-  <span class='ivar'>@name</span>     <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@timezone</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>timezone</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@name</span>     <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@timezone</span> <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>timezone</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -434,15 +428,15 @@
       <pre class="lines">
 
 
+17
+18
+19
 20
 21
-22
-23
-24
-25</pre>
+22</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 20</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 17</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -480,12 +474,12 @@
       <pre class="lines">
 
 
-16
-17
-18</pre>
+13
+14
+15</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 16</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 13</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_users'>users</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_organization_users'>organization_users</span>
@@ -500,7 +494,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:36 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Organization.html
+++ b/docs/Helium/Organization.html
@@ -209,7 +209,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, params:)  &#x21d2; Organization </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; Organization </a>
     
 
     
@@ -274,7 +274,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, params:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Organization (class)">Organization</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Organization (class)">Organization</a></span></tt> 
   
 
   
@@ -301,12 +301,18 @@
 7
 8
 9
-10</pre>
+10
+11
+12
+13</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 5</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>params:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+  
   <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 
   <span class='ivar'>@name</span>     <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
@@ -428,15 +434,15 @@
       <pre class="lines">
 
 
-17
-18
-19
 20
 21
-22</pre>
+22
+23
+24
+25</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 17</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 20</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -474,12 +480,12 @@
       <pre class="lines">
 
 
-13
-14
-15</pre>
+16
+17
+18</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 13</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/organization.rb', line 16</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_users'>users</span>
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_organization_users'>organization_users</span>
@@ -494,7 +500,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Resource.html
+++ b/docs/Helium/Resource.html
@@ -511,20 +511,18 @@
 10
 11
 12
-13
-14</pre>
+13</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 6</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+  <span class='ivar'>@client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='ivar'>@params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
 
-  <span class='ivar'>@client</span>     <span class='op'>=</span> <span class='id identifier rubyid_client'>client</span>
-  <span class='ivar'>@id</span>         <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>id</span><span class='tstring_end'>&quot;</span></span><span class='rbracket'>]</span>
-  <span class='ivar'>@created_at</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>created</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@updated_at</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>updated</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@id</span>         <span class='op'>=</span> <span class='ivar'>@params</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>id</span><span class='tstring_end'>&quot;</span></span><span class='rbracket'>]</span>
+  <span class='ivar'>@created_at</span> <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>created</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@updated_at</span> <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>updated</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -669,6 +667,7 @@
       <pre class="lines">
 
 
+23
 24
 25
 26
@@ -679,11 +678,10 @@
 31
 32
 33
-34
-35</pre>
+34</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 24</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 23</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_all'>all</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
@@ -799,6 +797,7 @@
       <pre class="lines">
 
 
+53
 54
 55
 56
@@ -814,11 +813,10 @@
 66
 67
 68
-69
-70</pre>
+69</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 54</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 53</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_create'>create</span><span class='lparen'>(</span><span class='id identifier rubyid_attributes'>attributes</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
@@ -939,17 +937,17 @@
       <pre class="lines">
 
 
+40
 41
 42
 43
 44
 45
 46
-47
-48</pre>
+47</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 41</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 40</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='id identifier rubyid_id'>id</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
@@ -1008,12 +1006,12 @@
       <pre class="lines">
 
 
+107
 108
-109
-110</pre>
+109</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 108</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 107</span>
 
 <span class='kw'>def</span> <span class='op'>==</span><span class='lparen'>(</span><span class='id identifier rubyid_other'>other</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span> <span class='op'>==</span> <span class='id identifier rubyid_other'>other</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span>
@@ -1065,16 +1063,16 @@
       <pre class="lines">
 
 
+137
 138
 139
 140
 141
 142
-143
-144</pre>
+143</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 138</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 137</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='lbrace'>{</span>
@@ -1130,13 +1128,13 @@
       <pre class="lines">
 
 
+124
 125
 126
-127
-128</pre>
+127</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 125</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 124</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_created_at'>created_at</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>if</span> <span class='ivar'>@created_at</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
@@ -1189,13 +1187,13 @@
       <pre class="lines">
 
 
+100
 101
 102
-103
-104</pre>
+103</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 101</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 100</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_destroy'>destroy</span>
   <span class='id identifier rubyid_path'>path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_resource_name'>resource_name</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
@@ -1244,12 +1242,12 @@
       <pre class="lines">
 
 
+113
 114
-115
-116</pre>
+115</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 114</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 113</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_eql?'>eql?</span><span class='lparen'>(</span><span class='id identifier rubyid_other'>other</span><span class='rparen'>)</span>
   <span class='kw'>self</span> <span class='op'>==</span> <span class='id identifier rubyid_other'>other</span>
@@ -1297,12 +1295,12 @@
       <pre class="lines">
 
 
+119
 120
-121
-122</pre>
+121</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 120</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 119</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_hash'>hash</span>
   <span class='id identifier rubyid_id'>id</span><span class='period'>.</span><span class='id identifier rubyid_hash'>hash</span>
@@ -1354,12 +1352,12 @@
       <pre class="lines">
 
 
+146
 147
-148
-149</pre>
+148</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 147</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 146</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_json'>to_json</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_as_json'>as_json</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
@@ -1430,6 +1428,7 @@
       <pre class="lines">
 
 
+81
 82
 83
 84
@@ -1444,11 +1443,10 @@
 93
 94
 95
-96
-97</pre>
+96</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 82</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 81</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_update'>update</span><span class='lparen'>(</span><span class='id identifier rubyid_attributes'>attributes</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_path'>path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_resource_name'>resource_name</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
@@ -1513,13 +1511,13 @@
       <pre class="lines">
 
 
+130
 131
 132
-133
-134</pre>
+133</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 131</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 130</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_updated_at'>updated_at</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>if</span> <span class='ivar'>@updated_at</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
@@ -1535,7 +1533,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:36 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Resource.html
+++ b/docs/Helium/Resource.html
@@ -166,7 +166,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#all-class_method" title="all (class method)">.<strong>all</strong>(client:)  &#x21d2; Array&lt;Resource&gt; </a>
+      <a href="#all-class_method" title="all (class method)">.<strong>all</strong>(opts = {})  &#x21d2; Array&lt;Resource&gt; </a>
     
 
     
@@ -189,7 +189,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#create-class_method" title="create (class method)">.<strong>create</strong>(attributes, client:)  &#x21d2; Resource </a>
+      <a href="#create-class_method" title="create (class method)">.<strong>create</strong>(attributes, opts = {})  &#x21d2; Resource </a>
     
 
     
@@ -212,7 +212,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#find-class_method" title="find (class method)">.<strong>find</strong>(id, client:)  &#x21d2; Resource </a>
+      <a href="#find-class_method" title="find (class method)">.<strong>find</strong>(id, opts = {})  &#x21d2; Resource </a>
     
 
     
@@ -382,7 +382,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, params:)  &#x21d2; Resource </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; Resource </a>
     
 
     
@@ -482,7 +482,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, params:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span></tt> 
   
 
   
@@ -509,12 +509,18 @@
 8
 9
 10
-11</pre>
+11
+12
+13
+14</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 6</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>params:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+
   <span class='ivar'>@client</span>     <span class='op'>=</span> <span class='id identifier rubyid_client'>client</span>
   <span class='ivar'>@id</span>         <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>id</span><span class='tstring_end'>&quot;</span></span><span class='rbracket'>]</span>
   <span class='ivar'>@created_at</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>created</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
@@ -582,7 +588,7 @@
       <div class="method_details first">
   <h3 class="signature first" id="all-class_method">
   
-    .<strong>all</strong>(client:)  &#x21d2; <tt>Array&lt;<span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span>&gt;</tt> 
+    .<strong>all</strong>(opts = {})  &#x21d2; <tt>Array&lt;<span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span>&gt;</tt> 
   
 
   
@@ -601,20 +607,43 @@
   
     <li>
       
-        <span class='name'>client</span>
+        <span class='name'>opts</span>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="Client.html" title="Helium::Client (class)">Client</a></span></tt>)</span>
+        <span class='type'>(<tt>Hash</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>{}</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>A Helium::Client</p>
+        <div class='inline'><p>a customizable set of options</p>
 </div>
       
     </li>
   
 </ul>
+
+  
+    
+    
+    <p class="tag_title">Options Hash (<tt>opts</tt>):</p>
+    <ul class="option">
+      
+        <li>
+          <span class="name">:client</span>
+          <span class="type">(<tt><span class='object_link'><a href="Client.html" title="Helium::Client (class)">Client</a></span></tt>)</span>
+          <span class="default">
+            
+          </span>
+          
+            &mdash; <div class='inline'><p>A Helium::Client</p>
+</div>
+          
+        </li>
+      
+    </ul>
+  
 
 <p class="tag_title">Returns:</p>
 <ul class="return">
@@ -640,21 +669,25 @@
       <pre class="lines">
 
 
-21
-22
-23
 24
 25
 26
 27
 28
 29
-30</pre>
+30
+31
+32
+33
+34
+35</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 21</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 24</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_all'>all</span><span class='lparen'>(</span><span class='label'>client:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_all'>all</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+
   <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_client'>client</span><span class='period'>.</span><span class='id identifier rubyid_get'>get</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_resource_name'>resource_name</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
   <span class='id identifier rubyid_resources_data'>resources_data</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>data</span><span class='tstring_end'>&quot;</span></span><span class='rbracket'>]</span>
 
@@ -672,7 +705,7 @@
       <div class="method_details ">
   <h3 class="signature " id="create-class_method">
   
-    .<strong>create</strong>(attributes, client:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span></tt> 
+    .<strong>create</strong>(attributes, opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span></tt> 
   
 
   
@@ -706,20 +739,45 @@
   
     <li>
       
-        <span class='name'>client</span>
+        <span class='name'>opts</span>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="Client.html" title="Helium::Client (class)">Client</a></span></tt>)</span>
+        <span class='type'>(<tt>Hash</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>{}</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>A Helium::Client</p>
+        <div class='inline'><p>a customizable set of options</p>
 </div>
       
     </li>
   
 </ul>
+
+  
+    
+    
+    
+    
+    <p class="tag_title">Options Hash (<tt>opts</tt>):</p>
+    <ul class="option">
+      
+        <li>
+          <span class="name">:client</span>
+          <span class="type">(<tt><span class='object_link'><a href="Client.html" title="Helium::Client (class)">Client</a></span></tt>)</span>
+          <span class="default">
+            
+          </span>
+          
+            &mdash; <div class='inline'><p>A Helium::Client</p>
+</div>
+          
+        </li>
+      
+    </ul>
+  
 
 <p class="tag_title">Returns:</p>
 <ul class="return">
@@ -741,13 +799,6 @@
       <pre class="lines">
 
 
-47
-48
-49
-50
-51
-52
-53
 54
 55
 56
@@ -755,12 +806,23 @@
 58
 59
 60
-61</pre>
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 47</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 54</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_create'>create</span><span class='lparen'>(</span><span class='id identifier rubyid_attributes'>attributes</span><span class='comma'>,</span> <span class='label'>client:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_create'>create</span><span class='lparen'>(</span><span class='id identifier rubyid_attributes'>attributes</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+
   <span class='id identifier rubyid_path'>path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_resource_name'>resource_name</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
 
   <span class='id identifier rubyid_body'>body</span> <span class='op'>=</span> <span class='lbrace'>{</span>
@@ -783,7 +845,7 @@
       <div class="method_details ">
   <h3 class="signature " id="find-class_method">
   
-    .<strong>find</strong>(id, client:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span></tt> 
+    .<strong>find</strong>(id, opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Resource (class)">Resource</a></span></tt> 
   
 
   
@@ -817,20 +879,45 @@
   
     <li>
       
-        <span class='name'>client</span>
+        <span class='name'>opts</span>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="Client.html" title="Helium::Client (class)">Client</a></span></tt>)</span>
+        <span class='type'>(<tt>Hash</tt>)</span>
       
+      
+        <em class="default">(defaults to: <tt>{}</tt>)</em>
       
       
         &mdash;
-        <div class='inline'><p>A Helium::Client</p>
+        <div class='inline'><p>a customizable set of options</p>
 </div>
       
     </li>
   
 </ul>
+
+  
+    
+    
+    
+    
+    <p class="tag_title">Options Hash (<tt>opts</tt>):</p>
+    <ul class="option">
+      
+        <li>
+          <span class="name">:client</span>
+          <span class="type">(<tt><span class='object_link'><a href="Client.html" title="Helium::Client (class)">Client</a></span></tt>)</span>
+          <span class="default">
+            
+          </span>
+          
+            &mdash; <div class='inline'><p>A Helium::Client</p>
+</div>
+          
+        </li>
+      
+    </ul>
+  
 
 <p class="tag_title">Returns:</p>
 <ul class="return">
@@ -852,17 +939,21 @@
       <pre class="lines">
 
 
-36
-37
-38
-39
-40
-41</pre>
+41
+42
+43
+44
+45
+46
+47
+48</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 36</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 41</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='id identifier rubyid_id'>id</span><span class='comma'>,</span> <span class='label'>client:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_find'>find</span><span class='lparen'>(</span><span class='id identifier rubyid_id'>id</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+
   <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_client'>client</span><span class='period'>.</span><span class='id identifier rubyid_get'>get</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_resource_name'>resource_name</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_id'>id</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
   <span class='id identifier rubyid_resource_data'>resource_data</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_body'>body</span><span class='rparen'>)</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>data</span><span class='tstring_end'>&quot;</span></span><span class='rbracket'>]</span>
 
@@ -917,12 +1008,12 @@
       <pre class="lines">
 
 
-99
-100
-101</pre>
+108
+109
+110</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 99</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 108</span>
 
 <span class='kw'>def</span> <span class='op'>==</span><span class='lparen'>(</span><span class='id identifier rubyid_other'>other</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span> <span class='op'>==</span> <span class='id identifier rubyid_other'>other</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span>
@@ -974,16 +1065,16 @@
       <pre class="lines">
 
 
-129
-130
-131
-132
-133
-134
-135</pre>
+138
+139
+140
+141
+142
+143
+144</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 129</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 138</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='lbrace'>{</span>
@@ -1039,13 +1130,13 @@
       <pre class="lines">
 
 
-116
-117
-118
-119</pre>
+125
+126
+127
+128</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 116</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 125</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_created_at'>created_at</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>if</span> <span class='ivar'>@created_at</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
@@ -1098,13 +1189,13 @@
       <pre class="lines">
 
 
-92
-93
-94
-95</pre>
+101
+102
+103
+104</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 92</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 101</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_destroy'>destroy</span>
   <span class='id identifier rubyid_path'>path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_resource_name'>resource_name</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
@@ -1153,12 +1244,12 @@
       <pre class="lines">
 
 
-105
-106
-107</pre>
+114
+115
+116</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 105</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 114</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_eql?'>eql?</span><span class='lparen'>(</span><span class='id identifier rubyid_other'>other</span><span class='rparen'>)</span>
   <span class='kw'>self</span> <span class='op'>==</span> <span class='id identifier rubyid_other'>other</span>
@@ -1206,12 +1297,12 @@
       <pre class="lines">
 
 
-111
-112
-113</pre>
+120
+121
+122</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 111</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 120</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_hash'>hash</span>
   <span class='id identifier rubyid_id'>id</span><span class='period'>.</span><span class='id identifier rubyid_hash'>hash</span>
@@ -1263,12 +1354,12 @@
       <pre class="lines">
 
 
-138
-139
-140</pre>
+147
+148
+149</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 138</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 147</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_json'>to_json</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_as_json'>as_json</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid_options'>options</span><span class='rparen'>)</span>
@@ -1339,25 +1430,25 @@
       <pre class="lines">
 
 
-73
-74
-75
-76
-77
-78
-79
-80
-81
 82
 83
 84
 85
 86
 87
-88</pre>
+88
+89
+90
+91
+92
+93
+94
+95
+96
+97</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 73</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 82</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_update'>update</span><span class='lparen'>(</span><span class='id identifier rubyid_attributes'>attributes</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_path'>path</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_resource_name'>resource_name</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_id'>id</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
@@ -1422,13 +1513,13 @@
       <pre class="lines">
 
 
-122
-123
-124
-125</pre>
+131
+132
+133
+134</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 122</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/resource.rb', line 131</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_updated_at'>updated_at</span>
   <span class='kw'>return</span> <span class='kw'>nil</span> <span class='kw'>if</span> <span class='ivar'>@updated_at</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
@@ -1444,7 +1535,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Sensor.html
+++ b/docs/Helium/Sensor.html
@@ -330,23 +330,17 @@
 8
 9
 10
-11
-12
-13
-14</pre>
+11</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 5</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+  <span class='kw'>super</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 
-  <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
-
-  <span class='ivar'>@name</span>  <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@mac</span>   <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>mac</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@ports</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ports</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@name</span>  <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@mac</span>   <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>mac</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@ports</span> <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ports</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -516,16 +510,16 @@
       <pre class="lines">
 
 
+32
+33
+34
 35
 36
 37
-38
-39
-40
-41</pre>
+38</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 35</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 32</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -554,6 +548,9 @@
       <pre class="lines">
 
 
+13
+14
+15
 16
 17
 18
@@ -567,13 +564,10 @@
 26
 27
 28
-29
-30
-31
-32</pre>
+29</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 16</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 13</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_timeseries'>timeseries</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_size'>size</span>        <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:size</span><span class='comma'>,</span> <span class='int'>1000</span><span class='rparen'>)</span>
@@ -602,7 +596,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:36 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Sensor.html
+++ b/docs/Helium/Sensor.html
@@ -238,7 +238,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, params:)  &#x21d2; Sensor </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; Sensor </a>
     
 
     
@@ -263,7 +263,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#timeseries-instance_method" title="#timeseries (instance method)">#<strong>timeseries</strong>(size: 1000, port: nil, start_time: nil, end_time: nil, aggtype: nil, aggsize: nil)  &#x21d2; Object </a>
+      <a href="#timeseries-instance_method" title="#timeseries (instance method)">#<strong>timeseries</strong>(opts = {})  &#x21d2; Object </a>
     
 
     
@@ -302,7 +302,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, params:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Sensor (class)">Sensor</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::Sensor (class)">Sensor</a></span></tt> 
   
 
   
@@ -330,12 +330,18 @@
 8
 9
 10
-11</pre>
+11
+12
+13
+14</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 5</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>params:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+
   <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 
   <span class='ivar'>@name</span>  <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
@@ -510,16 +516,16 @@
       <pre class="lines">
 
 
-25
-26
-27
-28
-29
-30
-31</pre>
+35
+36
+37
+38
+39
+40
+41</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 25</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 35</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -536,7 +542,7 @@
       <div class="method_details ">
   <h3 class="signature " id="timeseries-instance_method">
   
-    #<strong>timeseries</strong>(size: 1000, port: nil, start_time: nil, end_time: nil, aggtype: nil, aggsize: nil)  &#x21d2; <tt>Object</tt> 
+    #<strong>timeseries</strong>(opts = {})  &#x21d2; <tt>Object</tt> 
   
 
   
@@ -548,21 +554,35 @@
       <pre class="lines">
 
 
-13
-14
-15
 16
 17
 18
 19
 20
 21
-22</pre>
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 13</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/sensor.rb', line 16</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_timeseries'>timeseries</span><span class='lparen'>(</span><span class='label'>size:</span> <span class='int'>1000</span><span class='comma'>,</span> <span class='label'>port:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>start_time:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>end_time:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>aggtype:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>aggsize:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_timeseries'>timeseries</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_size'>size</span>        <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:size</span><span class='comma'>,</span> <span class='int'>1000</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_port'>port</span>        <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:port</span><span class='comma'>,</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_start_time'>start_time</span>  <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:start_time</span><span class='comma'>,</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_end_time'>end_time</span>    <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:end_time</span><span class='comma'>,</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_aggtype'>aggtype</span>     <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:aggtype</span><span class='comma'>,</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_aggsize'>aggsize</span>     <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:aggsize</span><span class='comma'>,</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+
   <span class='ivar'>@client</span><span class='period'>.</span><span class='id identifier rubyid_sensor_timeseries'>sensor_timeseries</span><span class='lparen'>(</span><span class='kw'>self</span><span class='comma'>,</span>
     <span class='label'>size:</span>       <span class='id identifier rubyid_size'>size</span><span class='comma'>,</span>
     <span class='label'>port:</span>       <span class='id identifier rubyid_port'>port</span><span class='comma'>,</span>
@@ -582,7 +602,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/User.html
+++ b/docs/Helium/User.html
@@ -279,22 +279,16 @@
 7
 8
 9
-10
-11
-12
-13</pre>
+10</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/user.rb', line 5</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+  <span class='kw'>super</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
 
-  <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
-
-  <span class='ivar'>@name</span>  <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='ivar'>@email</span> <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>email</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@name</span>  <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
+  <span class='ivar'>@email</span> <span class='op'>=</span> <span class='ivar'>@params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>meta</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>email</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -422,15 +416,15 @@
       <pre class="lines">
 
 
+13
+14
+15
 16
 17
-18
-19
-20
-21</pre>
+18</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/user.rb', line 16</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/user.rb', line 13</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -448,7 +442,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:48 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/User.html
+++ b/docs/Helium/User.html
@@ -210,7 +210,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(client:, params:)  &#x21d2; User </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(opts = {})  &#x21d2; User </a>
     
 
     
@@ -252,7 +252,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(client:, params:)  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::User (class)">User</a></span></tt> 
+    #<strong>initialize</strong>(opts = {})  &#x21d2; <tt><span class='object_link'><a href="" title="Helium::User (class)">User</a></span></tt> 
   
 
   
@@ -279,12 +279,18 @@
 7
 8
 9
-10</pre>
+10
+11
+12
+13</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/helium/user.rb', line 5</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>client:</span><span class='comma'>,</span> <span class='label'>params:</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_client'>client</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:client</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_params'>params</span> <span class='op'>=</span> <span class='id identifier rubyid_opts'>opts</span><span class='period'>.</span><span class='id identifier rubyid_fetch'>fetch</span><span class='lparen'>(</span><span class='symbol'>:params</span><span class='rparen'>)</span>
+
   <span class='kw'>super</span><span class='lparen'>(</span><span class='label'>client:</span> <span class='id identifier rubyid_client'>client</span><span class='comma'>,</span> <span class='label'>params:</span> <span class='id identifier rubyid_params'>params</span><span class='rparen'>)</span>
 
   <span class='ivar'>@name</span>  <span class='op'>=</span> <span class='id identifier rubyid_params'>params</span><span class='period'>.</span><span class='id identifier rubyid_dig'>dig</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>attributes</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>name</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
@@ -416,15 +422,15 @@
       <pre class="lines">
 
 
-13
-14
-15
 16
 17
-18</pre>
+18
+19
+20
+21</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/helium/user.rb', line 13</span>
+      <pre class="code"><span class="info file"># File 'lib/helium/user.rb', line 16</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_as_json'>as_json</span>
   <span class='kw'>super</span><span class='period'>.</span><span class='id identifier rubyid_merge'>merge</span><span class='lparen'>(</span><span class='lbrace'>{</span>
@@ -442,7 +448,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:48 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Utils.html
+++ b/docs/Helium/Utils.html
@@ -173,7 +173,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/Helium/Utils.html
+++ b/docs/Helium/Utils.html
@@ -173,7 +173,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -278,7 +278,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -278,7 +278,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -362,7 +362,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -362,7 +362,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -362,7 +362,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -362,7 +362,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -102,7 +102,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 15:14:47 2016 by
+  Generated on Tue Aug 23 15:32:35 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -102,7 +102,7 @@
 </div>
 
       <div id="footer">
-  Generated on Tue Aug 23 14:11:04 2016 by
+  Generated on Tue Aug 23 15:14:47 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.3 (ruby-2.3.1).
 </div>

--- a/lib/helium/client.rb
+++ b/lib/helium/client.rb
@@ -17,9 +17,9 @@ module Helium
 
     attr_accessor :api_key
 
-    def initialize(api_key:, debug: false)
-      @api_key = api_key
-      @debug = debug
+    def initialize(opts = {})
+      @api_key = opts.fetch(:api_key)
+      @debug   = opts.fetch(:debug, false)
     end
 
     def inspect

--- a/lib/helium/client/http.rb
+++ b/lib/helium/client/http.rb
@@ -12,10 +12,7 @@ module Helium
       }
 
       def get(path, opts = {})
-        params = opts.fetch(:params, {})
-
-        request = generate_request(path, method: :get, params: params)
-        run(request)
+        run(path, :get, opts)
       end
 
       def paginated_get(path, opts = {})
@@ -26,22 +23,15 @@ module Helium
       end
 
       def post(path, opts = {})
-        body = opts.fetch(:body, {})
-
-        request = generate_request(path, method: :post, body: body)
-        run(request)
+        run(path, :post, opts)
       end
 
       def patch(path, opts = {})
-        body = opts.fetch(:body, {})
-
-        request = generate_request(path, method: :patch, body: body)
-        run(request)
+        run(path, :patch, opts)
       end
 
       def delete(path)
-        request = generate_request(path, method: :delete)
-        response = run(request)
+        response = run(path, :delete)
         response.code == 204
       end
 
@@ -51,6 +41,12 @@ module Helium
         BASE_HTTP_HEADERS.merge({
           'Authorization' => api_key
         })
+      end
+
+      def run(path, method, opts = {})
+        request = generate_request(path, opts.merge(method: method))
+        response = run_request(request)
+        return response
       end
 
       def generate_request(path, opts = {})
@@ -74,7 +70,7 @@ module Helium
         })
       end
 
-      def run(request)
+      def run_request(request)
         request.run()
 
         if debug?

--- a/lib/helium/client/http.rb
+++ b/lib/helium/client/http.rb
@@ -11,21 +11,30 @@ module Helium
         'User-Agent'    => 'helium-ruby'
       }
 
-      def get(path = nil, url: nil, params: {})
-        request = generate_request(path, url: url, method: :get, params: params)
+      def get(path, opts = {})
+        params = opts.fetch(:params, {})
+
+        request = generate_request(path, method: :get, params: params)
         run(request)
       end
 
-      def paginated_get(path, klass:, params: {})
+      def paginated_get(path, opts = {})
+        klass  = opts.fetch(:klass)
+        params = opts.fetch(:params, {})
+
         Cursor.new(client: self, path: path, klass: klass, params: params)
       end
 
-      def post(path, body: {})
+      def post(path, opts = {})
+        body = opts.fetch(:body, {})
+
         request = generate_request(path, method: :post, body: body)
         run(request)
       end
 
-      def patch(path, body: {})
+      def patch(path, opts = {})
+        body = opts.fetch(:body, {})
+
         request = generate_request(path, method: :patch, body: body)
         run(request)
       end
@@ -44,9 +53,18 @@ module Helium
         })
       end
 
-      def generate_request(path = nil, url: nil, method:, params: {}, body: {})
-        path = path.gsub(/^\//, '') if path
-        url ||= "#{PROTOCOL}://#{HOST}/v#{API_VERSION}/#{path}"
+      def generate_request(path, opts = {})
+        method = opts.fetch(:method)
+        params = opts.fetch(:params, {})
+        body   = opts.fetch(:body, {})
+
+
+        url = if path =~ /^http/
+          path
+        else
+          path = path.gsub(/^\//, '')
+          "#{PROTOCOL}://#{HOST}/v#{API_VERSION}/#{path}"
+        end
 
         Typhoeus::Request.new(url, {
           method:   method,

--- a/lib/helium/client/labels.rb
+++ b/lib/helium/client/labels.rb
@@ -25,7 +25,9 @@ module Helium
         return sensors
       end
 
-      def update_label_sensors(label, sensors: [])
+      def update_label_sensors(label, opts = {})
+        sensors = opts.fetch(:sensors, [])
+
         path = "/label/#{label.id}/relationships/sensor"
 
         sensors = Array(sensors)

--- a/lib/helium/cursor.rb
+++ b/lib/helium/cursor.rb
@@ -2,11 +2,11 @@ module Helium
   class Cursor
     include Enumerable
 
-    def initialize(client:, path:, klass:, params: {})
-      @client = client
-      @path   = path
-      @klass  = klass
-      @params = params
+    def initialize(opts = {})
+      @client = opts.fetch(:client)
+      @path   = opts.fetch(:path)
+      @klass  = opts.fetch(:klass)
+      @params = opts.fetch(:params, {})
 
       @collection = []
       @next_link  = nil
@@ -37,7 +37,7 @@ module Helium
 
     def fetch_next_page
       if @next_link
-        response = @client.get(url: @next_link)
+        response = @client.get(@next_link)
       else
         response = @client.get(@path, params: @params)
       end

--- a/lib/helium/data_point.rb
+++ b/lib/helium/data_point.rb
@@ -2,7 +2,10 @@ module Helium
   class DataPoint < Resource
     attr_reader :timestamp, :value, :port
 
-    def initialize(client:, params:)
+    def initialize(opts = {})
+      client = opts.fetch(:client)
+      params = opts.fetch(:params)
+
       super(client: client, params: params)
 
       @timestamp  = params.dig("attributes", "timestamp")

--- a/lib/helium/data_point.rb
+++ b/lib/helium/data_point.rb
@@ -3,14 +3,11 @@ module Helium
     attr_reader :timestamp, :value, :port
 
     def initialize(opts = {})
-      client = opts.fetch(:client)
-      params = opts.fetch(:params)
+      super(opts)
 
-      super(client: client, params: params)
-
-      @timestamp  = params.dig("attributes", "timestamp")
-      @value      = params.dig("attributes", "value")
-      @port       = params.dig("attributes", "port")
+      @timestamp  = @params.dig("attributes", "timestamp")
+      @value      = @params.dig("attributes", "value")
+      @port       = @params.dig("attributes", "port")
     end
 
     def timestamp

--- a/lib/helium/element.rb
+++ b/lib/helium/element.rb
@@ -3,14 +3,11 @@ module Helium
     attr_reader :name, :mac, :versions
 
     def initialize(opts = {})
-      client = opts.fetch(:client)
-      params = opts.fetch(:params)
-      
-      super(client: client, params: params)
+      super(opts)
 
-      @name     = params.dig("attributes", "name")
-      @mac      = params.dig("meta", "mac")
-      @versions = params.dig("meta", "versions")
+      @name     = @params.dig("attributes", "name")
+      @mac      = @params.dig("meta", "mac")
+      @versions = @params.dig("meta", "versions")
     end
 
     # TODO can probably generalize this a bit more

--- a/lib/helium/element.rb
+++ b/lib/helium/element.rb
@@ -2,7 +2,10 @@ module Helium
   class Element < Resource
     attr_reader :name, :mac, :versions
 
-    def initialize(client:, params:)
+    def initialize(opts = {})
+      client = opts.fetch(:client)
+      params = opts.fetch(:params)
+      
       super(client: client, params: params)
 
       @name     = params.dig("attributes", "name")

--- a/lib/helium/label.rb
+++ b/lib/helium/label.rb
@@ -3,12 +3,9 @@ module Helium
     attr_reader :name
 
     def initialize(opts = {})
-      client = opts.fetch(:client)
-      params = opts.fetch(:params)
+      super(opts)
 
-      super(client: client, params: params)
-
-      @name = params.dig("attributes", "name")
+      @name = @params.dig("attributes", "name")
     end
 
     # TODO: would be nice to wrap this in a proxy collection, that way

--- a/lib/helium/label.rb
+++ b/lib/helium/label.rb
@@ -2,7 +2,10 @@ module Helium
   class Label < Resource
     attr_reader :name
 
-    def initialize(client:, params:)
+    def initialize(opts = {})
+      client = opts.fetch(:client)
+      params = opts.fetch(:params)
+
       super(client: client, params: params)
 
       @name = params.dig("attributes", "name")

--- a/lib/helium/organization.rb
+++ b/lib/helium/organization.rb
@@ -3,13 +3,10 @@ module Helium
     attr_reader :name, :timezone
 
     def initialize(opts = {})
-      client = opts.fetch(:client)
-      params = opts.fetch(:params)
-      
-      super(client: client, params: params)
+      super(opts)
 
-      @name     = params.dig('attributes', 'name')
-      @timezone = params.dig('attributes', 'timezone')
+      @name     = @params.dig('attributes', 'name')
+      @timezone = @params.dig('attributes', 'timezone')
     end
 
     # TODO refactor into relationships

--- a/lib/helium/organization.rb
+++ b/lib/helium/organization.rb
@@ -2,7 +2,10 @@ module Helium
   class Organization < Resource
     attr_reader :name, :timezone
 
-    def initialize(client:, params:)
+    def initialize(opts = {})
+      client = opts.fetch(:client)
+      params = opts.fetch(:params)
+      
       super(client: client, params: params)
 
       @name     = params.dig('attributes', 'name')

--- a/lib/helium/resource.rb
+++ b/lib/helium/resource.rb
@@ -3,7 +3,10 @@ module Helium
   class Resource
     attr_reader :id
 
-    def initialize(client:, params:)
+    def initialize(opts = {})
+      client = opts.fetch(:client)
+      params = opts.fetch(:params)
+
       @client     = client
       @id         = params["id"]
       @created_at = params.dig('meta', 'created')
@@ -18,7 +21,7 @@ module Helium
       # Returns all resources
       # @option opts [Client] :client A Helium::Client
       # @return [Array<Resource>] an Array of all of the inheriting Resource
-      def all(opts)
+      def all(opts = {})
         client = opts.fetch(:client)
 
         response = client.get("/#{resource_name}")
@@ -35,7 +38,7 @@ module Helium
       # @param id [String] An id to find the Resource
       # @option opts [Client] :client A Helium::Client
       # @return [Resource]
-      def find(id, opts)
+      def find(id, opts = {})
         client = opts.fetch(:client)
 
         response = client.get("/#{resource_name}/#{id}")
@@ -48,7 +51,7 @@ module Helium
       # @param attributes [Hash] The attributes for the new Resource
       # @option opts [Client] :client A Helium::Client
       # @return [Resource]
-      def create(attributes, opts)
+      def create(attributes, opts = {})
         client = opts.fetch(:client)
 
         path = "/#{resource_name}"

--- a/lib/helium/resource.rb
+++ b/lib/helium/resource.rb
@@ -4,13 +4,12 @@ module Helium
     attr_reader :id
 
     def initialize(opts = {})
-      client = opts.fetch(:client)
-      params = opts.fetch(:params)
+      @client = opts.fetch(:client)
+      @params = opts.fetch(:params)
 
-      @client     = client
-      @id         = params["id"]
-      @created_at = params.dig('meta', 'created')
-      @updated_at = params.dig('meta', 'updated')
+      @id         = @params["id"]
+      @created_at = @params.dig('meta', 'created')
+      @updated_at = @params.dig('meta', 'updated')
     end
 
     class << self

--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -2,7 +2,10 @@ module Helium
   class Sensor < Resource
     attr_reader :name, :mac, :ports
 
-    def initialize(client:, params:)
+    def initialize(opts = {})
+      client = opts.fetch(:client)
+      params = opts.fetch(:params)
+
       super(client: client, params: params)
 
       @name  = params.dig('attributes', 'name')
@@ -10,7 +13,14 @@ module Helium
       @ports = params.dig('meta', 'ports')
     end
 
-    def timeseries(size: 1000, port: nil, start_time: nil, end_time: nil, aggtype: nil, aggsize: nil)
+    def timeseries(opts = {})
+      size        = opts.fetch(:size, 1000)
+      port        = opts.fetch(:port, nil)
+      start_time  = opts.fetch(:start_time, nil)
+      end_time    = opts.fetch(:end_time, nil)
+      aggtype     = opts.fetch(:aggtype, nil)
+      aggsize     = opts.fetch(:aggsize, nil)
+
       @client.sensor_timeseries(self,
         size:       size,
         port:       port,

--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -3,14 +3,11 @@ module Helium
     attr_reader :name, :mac, :ports
 
     def initialize(opts = {})
-      client = opts.fetch(:client)
-      params = opts.fetch(:params)
+      super(opts)
 
-      super(client: client, params: params)
-
-      @name  = params.dig('attributes', 'name')
-      @mac   = params.dig('meta', 'mac')
-      @ports = params.dig('meta', 'ports')
+      @name  = @params.dig('attributes', 'name')
+      @mac   = @params.dig('meta', 'mac')
+      @ports = @params.dig('meta', 'ports')
     end
 
     def timeseries(opts = {})

--- a/lib/helium/user.rb
+++ b/lib/helium/user.rb
@@ -2,7 +2,10 @@ module Helium
   class User < Resource
     attr_reader :name, :email
 
-    def initialize(client:, params:)
+    def initialize(opts = {})
+      client = opts.fetch(:client)
+      params = opts.fetch(:params)
+
       super(client: client, params: params)
 
       @name  = params.dig('attributes', 'name')

--- a/lib/helium/user.rb
+++ b/lib/helium/user.rb
@@ -3,13 +3,10 @@ module Helium
     attr_reader :name, :email
 
     def initialize(opts = {})
-      client = opts.fetch(:client)
-      params = opts.fetch(:params)
+      super(opts)
 
-      super(client: client, params: params)
-
-      @name  = params.dig('attributes', 'name')
-      @email = params.dig('meta', 'email')
+      @name  = @params.dig('attributes', 'name')
+      @email = @params.dig('meta', 'email')
     end
 
     # TODO can probably generalize this a bit more


### PR DESCRIPTION
use the `opts.fetch` pattern to support versions of ruby that don't have keyword arguments.