### PR TITLE
Move `type` field to resource

### DIFF
--- a/lib/helium/resource.rb
+++ b/lib/helium/resource.rb
@@ -1,13 +1,14 @@
 module Helium
   # Abstract base class for Helium Resources returned by the API
   class Resource
-    attr_reader :id
+    attr_reader :id, :type
 
     def initialize(opts = {})
       @client = opts.fetch(:client)
       @params = opts.fetch(:params)
 
       @id         = @params["id"]
+      @type       = @params.dig('type')
       @created_at = @params.dig('meta', 'created')
       @updated_at = @params.dig('meta', 'updated')
     end
@@ -137,6 +138,7 @@ module Helium
     def as_json
       {
         id: id,
+        type: type,
         created_at: created_at,
         updated_at: updated_at
       }

--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -1,6 +1,6 @@
 module Helium
   class Sensor < Resource
-    attr_reader :name, :mac, :ports, :type, :last_seen, :firmware
+    attr_reader :name, :mac, :ports, :last_seen, :firmware
 
     def initialize(opts = {})
       super(opts)
@@ -8,7 +8,6 @@ module Helium
       @name      = @params.dig('attributes', 'name')
       @mac       = @params.dig('meta', 'mac')
       @ports     = @params.dig('meta', 'ports')
-      @type      = @params.dig('type')
       @last_seen = @params.dig('meta', 'last-seen')
       @firmware  = @params.dig('meta', 'versions', 'sensor')
 
@@ -45,7 +44,6 @@ module Helium
         mac: mac,
         ports: ports,
         last_seen: last_seen,
-        type: type,
         firmware: firmware
       })
     end

--- a/spec/helium/element_spec.rb
+++ b/spec/helium/element_spec.rb
@@ -16,6 +16,10 @@ describe Helium::Element do
     expect(element.mac).to eq("6081f9fffe0002a8")
   end
 
+  it 'has a type' do
+    expect(element.type).to eq("element")
+  end
+
   it 'has a created_at timestamp' do
     expect(element.created_at).to eq(DateTime.parse("2015-08-12T23:10:40.537762Z"))
   end

--- a/spec/helium/label_spec.rb
+++ b/spec/helium/label_spec.rb
@@ -14,6 +14,10 @@ describe Helium::Label do
     expect(label.name).to eq("The Isotopes")
   end
 
+  it 'has a type' do
+    expect(label.type).to eq("label")
+  end
+
   it 'has a created_at timestamp' do
     expect(label.created_at).to eq(DateTime.parse("2016-03-04T16:14:16.090864Z"))
   end

--- a/spec/helium/organization_spec.rb
+++ b/spec/helium/organization_spec.rb
@@ -7,6 +7,7 @@ describe Helium::Organization, '#to_json' do
   it 'is a JSON-encoded string representing the user' do
     decoded_json = JSON.parse(org.to_json)
     expect(decoded_json["id"]).to eq(org.id)
+    expect(decoded_json["type"]).to eq(org.type)
     expect(decoded_json["name"]).to eq(org.name)
   end
 end

--- a/spec/helium/user_spec.rb
+++ b/spec/helium/user_spec.rb
@@ -8,6 +8,7 @@ describe Helium::User, '#to_json' do
     decoded_json = JSON.parse(user.to_json)
     expect(decoded_json["id"]).to eq(user.id)
     expect(decoded_json["name"]).to eq(user.name)
+    expect(decoded_json["type"]).to eq(user.type)
     expect(decoded_json["email"]).to eq(user.email)
   end
 end


### PR DESCRIPTION
* `type` is available on all resources in the helium
API, so it should be moved into the Resource class

* Tests added for all resources