### PR TITLE
allow client to set a custom api host

### DIFF
--- a/lib/helium/client.rb
+++ b/lib/helium/client.rb
@@ -18,8 +18,9 @@ module Helium
     attr_accessor :api_key
 
     def initialize(opts = {})
-      @api_key = opts.fetch(:api_key)
-      @debug   = opts.fetch(:debug, false)
+      @api_key  = opts.fetch(:api_key)
+      @api_host = opts.fetch(:host, nil)
+      @debug    = opts.fetch(:debug, false)
     end
 
     def inspect

--- a/lib/helium/client.rb
+++ b/lib/helium/client.rb
@@ -15,11 +15,15 @@ module Helium
     include Helium::Client::Labels
     include Helium::Client::Elements
 
+    API_VERSION = 1
+    HOST        = 'api.helium.com'
+    PROTOCOL    = 'https'
+
     attr_accessor :api_key
 
     def initialize(opts = {})
       @api_key  = opts.fetch(:api_key)
-      @api_host = opts.fetch(:host, nil)
+      @api_host = opts.fetch(:host, HOST)
       @debug    = opts.fetch(:debug, false)
     end
 

--- a/lib/helium/client/http.rb
+++ b/lib/helium/client/http.rb
@@ -35,6 +35,20 @@ module Helium
         response.code == 204
       end
 
+      def base_url
+        host = @api_host || HOST
+        "#{PROTOCOL}://#{host}/v#{API_VERSION}"
+      end
+
+      # Contructs a proper url given a path. If the path is already a full url
+      # it will simply pass through
+      def url_for(path)
+        return path if path =~ /^http/
+
+        path = path.gsub(/^\//, '')
+        "#{base_url}/#{path}"
+      end
+
       private
 
       def http_headers
@@ -53,14 +67,7 @@ module Helium
         method = opts.fetch(:method)
         params = opts.fetch(:params, {})
         body   = opts.fetch(:body, {})
-
-
-        url = if path =~ /^http/
-          path
-        else
-          path = path.gsub(/^\//, '')
-          "#{PROTOCOL}://#{HOST}/v#{API_VERSION}/#{path}"
-        end
+        url    = url_for(path)
 
         Typhoeus::Request.new(url, {
           method:   method,

--- a/lib/helium/client/http.rb
+++ b/lib/helium/client/http.rb
@@ -1,10 +1,6 @@
 module Helium
   class Client
     module Http
-      API_VERSION = 1
-      HOST        = 'api.helium.com'
-      PROTOCOL    = 'https'
-
       BASE_HTTP_HEADERS = {
         'Accept'        => 'application/json',
         'Content-Type'  => 'application/json',
@@ -36,8 +32,7 @@ module Helium
       end
 
       def base_url
-        host = @api_host || HOST
-        "#{PROTOCOL}://#{host}/v#{API_VERSION}"
+        "#{PROTOCOL}://#{@api_host}/v#{API_VERSION}"
       end
 
       # Contructs a proper url given a path. If the path is already a full url

--- a/spec/helium/client_spec.rb
+++ b/spec/helium/client_spec.rb
@@ -34,4 +34,17 @@ describe Helium::Client do
 
     end
   end
+
+  context 'when providing a custom api host' do
+    let(:client) { Helium::Client.new(api_key: API_KEY, host: 'new.helium.com') }
+    it 'uses the custom host option for base_url' do
+      expect(client.base_url).to eq("https://new.helium.com/v1")
+    end
+  end
+
+  context 'when not providing a custom api host' do
+    it 'uses the default options for base_url' do
+      expect(client.base_url).to eq("https://api.helium.com/v1")
+    end
+  end
 end


### PR DESCRIPTION
custom hosts can be specified in the client opts:

```ruby
client = Helium::Client.new(api_key: '<key>', host: 'new.helium.com')
```