### PR TITLE
Adds missing endpoints for organization <-> element <-> sensor relationships

### DIFF
--- a/lib/helium/client/elements.rb
+++ b/lib/helium/client/elements.rb
@@ -10,9 +10,9 @@ module Helium
       end
 
       def element_sensors(element)
-        path = "/element/#{element.id}?include=sensor"
+        path = "/element/#{element.id}/sensor"
         response = get(path)
-        sensors_data = JSON.parse(response.body)["included"]
+        sensors_data = JSON.parse(response.body)["data"]
 
         sensors = sensors_data.map do |sensor|
           Sensor.new(client: self, params: sensor)

--- a/lib/helium/client/organizations.rb
+++ b/lib/helium/client/organizations.rb
@@ -17,6 +17,39 @@ module Helium
 
         return users
       end
+
+      def organization_labels
+        response = get('/organization/label')
+        labels_data = JSON.parse(response.body)["data"]
+
+        labels = labels_data.map do |label_data|
+          Label.new(client: self, params: label_data)
+        end
+
+        return labels
+      end
+
+      def organization_elements
+        response = get('/organization/element')
+        elements_data = JSON.parse(response.body)["data"]
+
+        elements = elements_data.map do |element_data|
+          Element.new(client: self, params: element_data)
+        end
+
+        return elements
+      end
+
+      def organization_sensors
+        response = get('/organization/sensor')
+        sensors_data = JSON.parse(response.body)["data"]
+
+        sensors = sensors_data.map do |sensor_data|
+          Sensor.new(client: self, params: sensor_data)
+        end
+
+        return sensors
+      end
     end
   end
 end

--- a/lib/helium/client/sensors.rb
+++ b/lib/helium/client/sensors.rb
@@ -9,6 +9,15 @@ module Helium
         Sensor.find(id, client: self)
       end
 
+      def sensor_element(sensor)
+        path = "/sensor/#{sensor.id}/element"
+        response = get(path)
+        elementj = JSON.parse(response.body)["data"]
+        element = Element.new(client: self, params: elementj)
+
+        return element
+      end
+
       def sensor_timeseries(sensor, opts = {})
         path = "/sensor/#{sensor.id}/timeseries"
 

--- a/lib/helium/organization.rb
+++ b/lib/helium/organization.rb
@@ -14,6 +14,18 @@ module Helium
       @client.organization_users
     end
 
+    def labels
+      @client.organization_labels
+    end
+
+    def elements
+      @client.organization_elements
+    end
+
+    def sensors
+      @client.organization_sensors
+    end
+
     def as_json
       super.merge({
         name: name,

--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -11,6 +11,10 @@ module Helium
       @last_seen = @params.dig('meta', 'last-seen')
     end
 
+    def element
+      @client.sensor_element(self)
+    end
+
     def self.all_path
       "/sensor?include=label"
     end

--- a/lib/helium/version.rb
+++ b/lib/helium/version.rb
@@ -1,3 +1,3 @@
 module Helium
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end

--- a/spec/helium/client/organizations_spec.rb
+++ b/spec/helium/client/organizations_spec.rb
@@ -54,3 +54,62 @@ describe Helium::Organization, '#users' do
     expect(user.pending_invite).to eq(false)
   end
 end
+
+describe Helium::Organization, '#labels' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:organization) { client.organization }
+
+  use_cassette 'organization/labels'
+
+  it 'returns the Labels associated with the organization' do
+    labels = organization.labels
+    expect(labels).to be_an(Array)
+    expect(labels).to all( be_a(Helium::Label) )
+  end
+
+  it 'returns proper Labels' do
+    label = organization.labels.first
+    expect(label.name).to eq("SF Office")
+    expect(label.id).to eq("ce9aad92-70d0-44a3-9ba4-8bc834d71256")
+  end
+end
+
+describe Helium::Organization, '#elements' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:organization) { client.organization }
+
+  use_cassette 'organization/elements'
+
+  it 'returns the Elements associated with the organization' do
+    elements = organization.elements
+    expect(elements).to be_an(Array)
+    expect(elements).to all( be_a(Helium::Element) )
+  end
+
+  it 'returns proper Elements' do
+    element = organization.elements.first
+    expect(element.name).to eq("Coco's Element")
+    expect(element.id).to eq("483e3c7d-8f42-45bc-a21d-c45e02edc80d")
+    expect(element.mac).to eq("6081f9fffe0002f0")
+  end
+end
+
+describe Helium::Organization, '#sensors' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:organization) { client.organization }
+
+  use_cassette 'organization/sensors'
+
+  it 'returns the Sensors associated with the organization' do
+    sensors = organization.sensors
+    expect(sensors).to be_an(Array)
+    expect(sensors).to all( be_a(Helium::Sensor) )
+  end
+
+  it 'returns proper Sensors' do
+    sensor = organization.sensors.first
+    expect(sensor.name).to eq("COS MiniDemo Sensor")
+    expect(sensor.id).to eq("6d3df343-6620-4e96-b1fc-5fd4141b0a8d")
+    expect(sensor.mac).to eq("6081f9fffe000777")
+  end
+end

--- a/spec/helium/element_spec.rb
+++ b/spec/helium/element_spec.rb
@@ -45,21 +45,21 @@ end
 
 describe Helium::Element, '#sensors' do
   let(:client) { Helium::Client.new(api_key: API_KEY) }
-  let(:element) { client.element("3482ce9f-599c-4982-bcb9-e94df65b1cb2") }
+  let(:element) { client.element("2c59f726-5316-49a7-857a-33ae63b126a4") }
   let(:sensors) { element.sensors }
 
   use_cassette 'elements/sensors'
 
   it 'returns all sensors attached to a element' do
-    expect(sensors.length).to eq(2)
+    expect(sensors.length).to eq(3)
   end
 
   it 'returns fully formed sensors' do
     sensor = sensors.first
-    expect(sensor.id).to eq("94683401-4959-42c7-a38a-92c39a25f34c")
-    expect(sensor.mac).to eq("6081f9fffe000665")
-    expect(sensor.name).to eq("Mobile Demo Green 3")
-    expect(sensor.ports).to eq(["_b", "_se", "b", "h", "l", "m", "p", "t"])
+    expect(sensor.id).to eq("47da7cef-f0c5-43fb-85e0-b4b23d3ddb05")
+    expect(sensor.mac).to eq("6081f9fffe00068d")
+    expect(sensor.name).to eq("TC Suite")
+    expect(sensor.ports).to eq(["_se","_b","b","m","l","p","h","t"])
   end
 end
 

--- a/spec/helium/sensor_spec.rb
+++ b/spec/helium/sensor_spec.rb
@@ -1,5 +1,19 @@
 require 'spec_helper'
 
+describe Helium::Sensor, '#element' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:sensor) { client.sensor("5af6c914-4232-4fda-9e38-1e76597e539b") }
+  let(:element) { sensor.element }
+
+  use_cassette 'sensor/element'
+
+  it 'returns fully formed element' do
+    expect(element.id).to eq("cb9f0005-5c63-4571-bc46-209f65de9a1c")
+    expect(element.mac).to eq("6081f9fffe0002f5")
+    expect(element.name).to eq("Element 2")
+  end
+end
+
 describe Helium::Sensor, '#to_json' do
   let(:client) { instance_double(Helium::Client) }
   let(:sensor) { described_class.new(client: client, params: SENSOR_PARAMS) }

--- a/spec/vcr/elements/sensors.yml
+++ b/spec/vcr/elements/sensors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.helium.com/v1/element/3482ce9f-599c-4982-bcb9-e94df65b1cb2
+    uri: https://api.helium.com/v1/element/2c59f726-5316-49a7-857a-33ae63b126a4
     body:
       encoding: UTF-8
       string: "{}"
@@ -22,32 +22,34 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Wed, 24 Aug 2016 21:40:12 GMT
-      Server:
-      - Warp/3.2.7
-      Access-Control-Allow-Origin:
-      - "*"
       Access-Control-Allow-Headers:
       - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
-      Airship-Quip:
-      - 'WARNING: ulimit -n is 1024'
       Content-Type:
       - application/json
+      Date:
+      - Wed, 12 Oct 2016 21:52:26 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '569'
+      Connection:
+      - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"SF Office"},"relationships":{"metadata":{"data":{"id":"3482ce9f-599c-4982-bcb9-e94df65b1cb2","type":"metadata"}},"organization":{"data":{"id":"134","type":"organization"}},"sensor":{"data":[{"id":"94683401-4959-42c7-a38a-92c39a25f34c","type":"sensor"},{"id":"ec76206d-4ad3-4a42-8fa5-93c1dd06681e","type":"sensor"}]}},"id":"3482ce9f-599c-4982-bcb9-e94df65b1cb2","meta":{"mac":"6081f9fffe0001f1","created":"2015-08-12T22:38:53.724511Z","versions":{"element":"3050900"},"updated":"2015-12-09T19:35:11.675927Z"},"type":"element"}}'
+      string: '{"data":{"attributes":{"name":"Element 2"},"relationships":{"metadata":{"data":{"id":"2c59f726-5316-49a7-857a-33ae63b126a4","type":"metadata"}},"sensor":{"data":[{"id":"47da7cef-f0c5-43fb-85e0-b4b23d3ddb05","type":"sensor"},{"id":"1daa7686-0c97-401a-8186-eb3344f0bf63","type":"sensor"},{"id":"ec247d87-4e17-418b-8236-cd7b138cde75","type":"sensor"}]}},"id":"2c59f726-5316-49a7-857a-33ae63b126a4","meta":{"mac":"6081f9fffe0002c9","created":"2016-06-29T22:55:40.512098Z","last-seen":"2016-10-11T10:28:56.686616Z","updated":"2016-06-29T22:55:40.512098Z"},"type":"element"}}'
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/element/3482ce9f-599c-4982-bcb9-e94df65b1cb2
-  recorded_at: Wed, 24 Aug 2016 21:40:12 GMT
+      effective_url: https://api.helium.com/v1/element/2c59f726-5316-49a7-857a-33ae63b126a4
+  recorded_at: Wed, 12 Oct 2016 21:52:26 GMT
 - request:
     method: get
-    uri: https://api.helium.com/v1/element/3482ce9f-599c-4982-bcb9-e94df65b1cb2?include=sensor
+    uri: https://api.helium.com/v1/element/2c59f726-5316-49a7-857a-33ae63b126a4/sensor
     body:
       encoding: UTF-8
       string: "{}"
@@ -67,30 +69,31 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Wed, 24 Aug 2016 21:40:12 GMT
-      Server:
-      - Warp/3.2.7
-      Access-Control-Allow-Origin:
-      - "*"
       Access-Control-Allow-Headers:
       - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
-      Airship-Quip:
-      - RB_GC_GUARD
       Content-Type:
       - application/json
+      Date:
+      - Wed, 12 Oct 2016 21:52:26 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '946'
+      Connection:
+      - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"SF Office"},"relationships":{"metadata":{"data":{"id":"3482ce9f-599c-4982-bcb9-e94df65b1cb2","type":"metadata"}},"organization":{"data":{"id":"134","type":"organization"}},"sensor":{"data":[{"id":"94683401-4959-42c7-a38a-92c39a25f34c","type":"sensor"},{"id":"ec76206d-4ad3-4a42-8fa5-93c1dd06681e","type":"sensor"}]}},"id":"3482ce9f-599c-4982-bcb9-e94df65b1cb2","meta":{"mac":"6081f9fffe0001f1","created":"2015-08-12T22:38:53.724511Z","versions":{"element":"3050900"},"updated":"2015-12-09T19:35:11.675927Z"},"type":"element"},"included":[{"attributes":{"name":"Mobile
-        Demo Green 3"},"id":"94683401-4959-42c7-a38a-92c39a25f34c","meta":{"card":{"id":5},"mac":"6081f9fffe000665","created":"2016-05-25T00:03:38.059788Z","versions":{"sensor-script":[{"version":"32245382e6cfd8f2"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"}],"atom":"2050b00","sensor-config":"4b90039b34373ad2","sensor-library":"c8a1ae32682196c4","sensor":"4020300"},"last-seen":"2016-06-24T00:07:02.391306Z","ports":["_b","_se","b","h","l","m","p","t"],"updated":"2016-05-25T00:03:38.059975Z"},"type":"sensor"},{"attributes":{"name":"Mini
-        Fridge 1.1"},"id":"ec76206d-4ad3-4a42-8fa5-93c1dd06681e","meta":{"card":{"id":2},"mac":"6081f9fffe0006aa","created":"2016-06-14T00:07:58.761507Z","versions":{"sensor-script":[{"version":"aa1066c4526acd91"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"},{"version":"ffffffffffffffff"}],"atom":"2050b00","sensor-config":"c0e0315e1e7e205b","sensor-library":"d63a73ed260381af","sensor":"4020300"},"last-seen":"2016-06-29T18:21:04.302722Z","ports":["_b","_se","b","d","Glowfish
-        Alert Level","t"],"updated":"2016-08-03T11:10:33.436857Z"},"type":"sensor"}]}'
+      string: '{"data":[{"attributes":{"name":"TC Suite"},"id":"47da7cef-f0c5-43fb-85e0-b4b23d3ddb05","meta":{"card":{"id":5},"mac":"6081f9fffe00068d","created":"2016-07-12T21:10:37.879131Z","last-seen":"2016-10-12T21:51:02.33652Z","ports":["_se","_b","b","m","l","p","h","t"],"updated":"2016-07-18T18:16:36.803118Z"},"type":"sensor"},{"attributes":{"name":"Main
+        Lab"},"id":"1daa7686-0c97-401a-8186-eb3344f0bf63","meta":{"card":{"id":5},"mac":"6081f9fffe00063b","created":"2016-07-12T21:09:56.894341Z","last-seen":"2016-10-12T21:48:45.221913Z","ports":["_se","m","_b","b","p","h","t","l"],"updated":"2016-07-18T17:39:27.750782Z"},"type":"sensor"},{"attributes":{"name":"4
+        Degree - Right Side"},"id":"ec247d87-4e17-418b-8236-cd7b138cde75","meta":{"card":{"id":2},"mac":"6081f9fffe00042a","created":"2016-07-12T21:08:42.548113Z","last-seen":"2016-10-12T21:51:02.355265Z","ports":["_se","_b","b","d","t"],"updated":"2016-07-18T18:37:42.617094Z"},"type":"sensor"}]}'
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/element/3482ce9f-599c-4982-bcb9-e94df65b1cb2?include=sensor
-  recorded_at: Wed, 24 Aug 2016 21:40:12 GMT
+      effective_url: https://api.helium.com/v1/element/2c59f726-5316-49a7-857a-33ae63b126a4/sensor
+  recorded_at: Wed, 12 Oct 2016 21:52:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/organization/elements.yml
+++ b/spec/vcr/organization/elements.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/organization
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Oct 2016 14:11:59 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '2254'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"demos@helium.com","timezone":"US/Pacific"},"relationships":{"user":{"data":[{"id":"restricted@helium.com","type":"user"},{"id":"demos@helium.com","type":"user"}]},"metadata":{"data":{"id":"demos@helium.com","type":"metadata"}},"sensor":{"data":[{"id":"6d3df343-6620-4e96-b1fc-5fd4141b0a8d","type":"sensor"},{"id":"9e88aab7-09c1-4a18-a9c1-6e91780d759e","type":"sensor"},{"id":"5be9b35b-6f94-4d9c-8d7a-cafa9b8b6dee","type":"sensor"},{"id":"94683401-4959-42c7-a38a-92c39a25f34c","type":"sensor"},{"id":"3df4e2e0-0549-4a84-8fb6-442233ce8356","type":"sensor"},{"id":"32eedf4b-4c64-4708-a670-91af6080ede8","type":"sensor"},{"id":"ec76206d-4ad3-4a42-8fa5-93c1dd06681e","type":"sensor"},{"id":"445d5235-646d-4dc9-9bb8-58e21d9ccc44","type":"sensor"},{"id":"33041ecd-5c5e-45aa-80c1-5fa3333ab21f","type":"sensor"},{"id":"cb396f82-50f8-4758-9c1f-6c441e3277df","type":"sensor"},{"id":"e64ac3b3-518d-4528-90ff-1a1a7ef7c41f","type":"sensor"},{"id":"9b8b3247-1d2e-41a6-9052-1feff28713d3","type":"sensor"}]},"element":{"data":[{"id":"483e3c7d-8f42-45bc-a21d-c45e02edc80d","type":"element"},{"id":"81c0b9b2-da81-4231-94e0-850948818efe","type":"element"},{"id":"1060cd07-fc94-4adb-a8e6-694032608139","type":"element"},{"id":"8e8c6060-266c-41b6-8c00-14f8d2d7520b","type":"element"},{"id":"74e42387-0941-4700-b961-d4a02225f55f","type":"element"},{"id":"e86a08a2-9c0c-432a-ba1f-7bc4aebf9d55","type":"element"},{"id":"43ad565d-6475-44a0-8752-c45c6de43e0f","type":"element"},{"id":"c0229362-846c-4e8d-8d0f-9575f09fbb58","type":"element"},{"id":"b9660760-03c2-451c-84f2-2a77f4f15d2e","type":"element"}]},"label":{"data":[{"id":"ce9aad92-70d0-44a3-9ba4-8bc834d71256","type":"label"},{"id":"4461ceeb-aec7-4ca3-968e-e4b07ae6a597","type":"label"},{"id":"65dc35c7-5c95-4e2d-a2e4-c72051ee1919","type":"label"},{"id":"d50305f2-f8e2-4552-8d2d-6318fbfc8f2c","type":"label"},{"id":"8c058249-ce71-47c5-aa97-282ee37d887e","type":"label"},{"id":"364779ed-a949-4456-ba2c-e7307427f147","type":"label"},{"id":"c76d961c-7dbf-46fb-afb9-4a83cf7dbc05","type":"label"},{"id":"91a080a5-d739-4460-a00a-79cd4ecde5a0","type":"label"}]}},"id":"demos@helium.com","meta":{"created":"2015-09-10T20:50:18.183896Z","updated":"2016-03-01T16:58:38.832646Z"},"type":"organization"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/organization
+  recorded_at: Thu, 13 Oct 2016 14:11:59 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/organization/element
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Oct 2016 14:11:59 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '2260'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"Coco''s Element"},"id":"483e3c7d-8f42-45bc-a21d-c45e02edc80d","meta":{"mac":"6081f9fffe0002f0","created":"2016-05-11T22:55:49.601144Z","last-seen":"2016-10-07T23:21:46.204363Z","updated":"2016-05-11T22:55:49.601144Z"},"type":"element"},{"attributes":{"name":"Mobile
+        Demo Element 2"},"id":"81c0b9b2-da81-4231-94e0-850948818efe","meta":{"mac":"6081f9fffe0000c8","created":"2016-04-29T00:09:39.972591Z","last-seen":"2016-05-31T17:13:11.511232Z","updated":"2016-04-29T00:09:39.972591Z"},"type":"element"},{"attributes":{"name":"Demo
+        Element 1"},"id":"1060cd07-fc94-4adb-a8e6-694032608139","meta":{"mac":"6081f9fffe000309","created":"2016-04-28T23:13:22.42593Z","last-seen":"2016-06-24T17:06:33.518557Z","updated":"2016-04-28T23:13:22.42593Z"},"type":"element"},{"attributes":{"name":"SF
+        Office 3"},"id":"8e8c6060-266c-41b6-8c00-14f8d2d7520b","meta":{"mac":"6081f9fffe0000f2","created":"2016-04-27T18:19:06.520815Z","last-seen":"2016-08-22T22:02:25.382924Z","updated":"2016-04-27T18:19:06.520815Z"},"type":"element"},{"attributes":{"name":"Demo
+        Element 1"},"id":"74e42387-0941-4700-b961-d4a02225f55f","meta":{"mac":"6081f9fffe0005e7","created":"2016-04-27T18:19:06.520815Z","last-seen":null,"updated":"2016-04-27T18:19:06.520815Z"},"type":"element"},{"attributes":{"name":"SF
+        Office"},"id":"e86a08a2-9c0c-432a-ba1f-7bc4aebf9d55","meta":{"mac":"6081f9fffe0001ef","created":"2016-04-27T18:19:06.520815Z","last-seen":null,"updated":"2016-04-27T18:19:06.520815Z"},"type":"element"},{"attributes":{"name":"COS
+        Demo Element (actual)"},"id":"43ad565d-6475-44a0-8752-c45c6de43e0f","meta":{"mac":"6081f9fffe000158","created":"2016-04-27T18:19:06.520815Z","last-seen":null,"updated":"2016-04-27T18:19:06.520815Z"},"type":"element"},{"attributes":{"name":"SF
+        Office"},"id":"c0229362-846c-4e8d-8d0f-9575f09fbb58","meta":{"mac":"6081f9fffe0001f1","created":"2016-04-27T18:19:06.520815Z","last-seen":"2016-08-22T22:00:59.332769Z","updated":"2016-04-27T18:19:06.520815Z"},"type":"element"},{"attributes":{"name":"Demo
+        Element 2"},"id":"b9660760-03c2-451c-84f2-2a77f4f15d2e","meta":{"mac":"6081f9fffe0006ce","created":"2016-04-27T18:19:06.520815Z","last-seen":"2016-10-12T22:06:38.951646Z","updated":"2016-04-27T18:19:06.520815Z"},"type":"element"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/organization/element
+  recorded_at: Thu, 13 Oct 2016 14:11:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/organization/labels.yml
+++ b/spec/vcr/organization/labels.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/organization
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Oct 2016 14:11:59 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '2254'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"demos@helium.com","timezone":"US/Pacific"},"relationships":{"user":{"data":[{"id":"restricted@helium.com","type":"user"},{"id":"demos@helium.com","type":"user"}]},"metadata":{"data":{"id":"demos@helium.com","type":"metadata"}},"sensor":{"data":[{"id":"6d3df343-6620-4e96-b1fc-5fd4141b0a8d","type":"sensor"},{"id":"9e88aab7-09c1-4a18-a9c1-6e91780d759e","type":"sensor"},{"id":"5be9b35b-6f94-4d9c-8d7a-cafa9b8b6dee","type":"sensor"},{"id":"94683401-4959-42c7-a38a-92c39a25f34c","type":"sensor"},{"id":"3df4e2e0-0549-4a84-8fb6-442233ce8356","type":"sensor"},{"id":"32eedf4b-4c64-4708-a670-91af6080ede8","type":"sensor"},{"id":"ec76206d-4ad3-4a42-8fa5-93c1dd06681e","type":"sensor"},{"id":"445d5235-646d-4dc9-9bb8-58e21d9ccc44","type":"sensor"},{"id":"33041ecd-5c5e-45aa-80c1-5fa3333ab21f","type":"sensor"},{"id":"cb396f82-50f8-4758-9c1f-6c441e3277df","type":"sensor"},{"id":"e64ac3b3-518d-4528-90ff-1a1a7ef7c41f","type":"sensor"},{"id":"9b8b3247-1d2e-41a6-9052-1feff28713d3","type":"sensor"}]},"element":{"data":[{"id":"483e3c7d-8f42-45bc-a21d-c45e02edc80d","type":"element"},{"id":"81c0b9b2-da81-4231-94e0-850948818efe","type":"element"},{"id":"1060cd07-fc94-4adb-a8e6-694032608139","type":"element"},{"id":"8e8c6060-266c-41b6-8c00-14f8d2d7520b","type":"element"},{"id":"74e42387-0941-4700-b961-d4a02225f55f","type":"element"},{"id":"e86a08a2-9c0c-432a-ba1f-7bc4aebf9d55","type":"element"},{"id":"43ad565d-6475-44a0-8752-c45c6de43e0f","type":"element"},{"id":"c0229362-846c-4e8d-8d0f-9575f09fbb58","type":"element"},{"id":"b9660760-03c2-451c-84f2-2a77f4f15d2e","type":"element"}]},"label":{"data":[{"id":"ce9aad92-70d0-44a3-9ba4-8bc834d71256","type":"label"},{"id":"4461ceeb-aec7-4ca3-968e-e4b07ae6a597","type":"label"},{"id":"65dc35c7-5c95-4e2d-a2e4-c72051ee1919","type":"label"},{"id":"d50305f2-f8e2-4552-8d2d-6318fbfc8f2c","type":"label"},{"id":"8c058249-ce71-47c5-aa97-282ee37d887e","type":"label"},{"id":"364779ed-a949-4456-ba2c-e7307427f147","type":"label"},{"id":"c76d961c-7dbf-46fb-afb9-4a83cf7dbc05","type":"label"},{"id":"91a080a5-d739-4460-a00a-79cd4ecde5a0","type":"label"}]}},"id":"demos@helium.com","meta":{"created":"2015-09-10T20:50:18.183896Z","updated":"2016-03-01T16:58:38.832646Z"},"type":"organization"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/organization
+  recorded_at: Thu, 13 Oct 2016 14:11:59 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/organization/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Oct 2016 14:11:59 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1504'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"SF Office"},"id":"ce9aad92-70d0-44a3-9ba4-8bc834d71256","meta":{"created":"2015-07-21T19:48:25.335729Z","updated":"2015-07-21T19:48:25.335729Z"},"type":"label"},{"attributes":{"name":"Pediatric
+        Fridges"},"id":"4461ceeb-aec7-4ca3-968e-e4b07ae6a597","meta":{"created":"2015-11-13T15:49:05.946824Z","updated":"2016-04-13T21:10:32.089096Z"},"type":"label"},{"attributes":{"name":"Roamers"},"id":"65dc35c7-5c95-4e2d-a2e4-c72051ee1919","meta":{"created":"2016-03-14T23:49:28.171765Z","updated":"2016-04-13T21:10:21.311346Z"},"type":"label"},{"attributes":{"name":"Mini
+        Fridges"},"id":"d50305f2-f8e2-4552-8d2d-6318fbfc8f2c","meta":{"created":"2016-04-13T21:07:10.517247Z","updated":"2016-04-13T21:07:15.619866Z"},"type":"label"},{"attributes":{"name":"SF
+        Office Teal Room"},"id":"8c058249-ce71-47c5-aa97-282ee37d887e","meta":{"created":"2016-05-16T23:03:56.873626Z","updated":"2016-05-16T23:04:12.452239Z"},"type":"label"},{"attributes":{"name":"test
+        label 2"},"id":"364779ed-a949-4456-ba2c-e7307427f147","meta":{"created":"2016-06-29T17:36:33.59802Z","updated":"2016-06-29T17:36:39.643884Z"},"type":"label"},{"attributes":{"name":"5
+        Washington"},"id":"c76d961c-7dbf-46fb-afb9-4a83cf7dbc05","meta":{"created":"2016-06-29T19:30:03.498907Z","updated":"2016-06-29T19:30:13.010948Z"},"type":"label"},{"attributes":{"name":"New
+        Label"},"id":"91a080a5-d739-4460-a00a-79cd4ecde5a0","meta":{"created":"2016-07-27T18:45:54.20208Z","updated":"2016-07-27T18:45:54.20208Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/organization/label
+  recorded_at: Thu, 13 Oct 2016 14:11:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/organization/sensors.yml
+++ b/spec/vcr/organization/sensors.yml
@@ -1,0 +1,109 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/organization
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Oct 2016 14:11:59 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '2254'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"demos@helium.com","timezone":"US/Pacific"},"relationships":{"user":{"data":[{"id":"restricted@helium.com","type":"user"},{"id":"demos@helium.com","type":"user"}]},"metadata":{"data":{"id":"demos@helium.com","type":"metadata"}},"sensor":{"data":[{"id":"6d3df343-6620-4e96-b1fc-5fd4141b0a8d","type":"sensor"},{"id":"9e88aab7-09c1-4a18-a9c1-6e91780d759e","type":"sensor"},{"id":"5be9b35b-6f94-4d9c-8d7a-cafa9b8b6dee","type":"sensor"},{"id":"94683401-4959-42c7-a38a-92c39a25f34c","type":"sensor"},{"id":"3df4e2e0-0549-4a84-8fb6-442233ce8356","type":"sensor"},{"id":"32eedf4b-4c64-4708-a670-91af6080ede8","type":"sensor"},{"id":"ec76206d-4ad3-4a42-8fa5-93c1dd06681e","type":"sensor"},{"id":"445d5235-646d-4dc9-9bb8-58e21d9ccc44","type":"sensor"},{"id":"33041ecd-5c5e-45aa-80c1-5fa3333ab21f","type":"sensor"},{"id":"cb396f82-50f8-4758-9c1f-6c441e3277df","type":"sensor"},{"id":"e64ac3b3-518d-4528-90ff-1a1a7ef7c41f","type":"sensor"},{"id":"9b8b3247-1d2e-41a6-9052-1feff28713d3","type":"sensor"}]},"element":{"data":[{"id":"483e3c7d-8f42-45bc-a21d-c45e02edc80d","type":"element"},{"id":"81c0b9b2-da81-4231-94e0-850948818efe","type":"element"},{"id":"1060cd07-fc94-4adb-a8e6-694032608139","type":"element"},{"id":"8e8c6060-266c-41b6-8c00-14f8d2d7520b","type":"element"},{"id":"74e42387-0941-4700-b961-d4a02225f55f","type":"element"},{"id":"e86a08a2-9c0c-432a-ba1f-7bc4aebf9d55","type":"element"},{"id":"43ad565d-6475-44a0-8752-c45c6de43e0f","type":"element"},{"id":"c0229362-846c-4e8d-8d0f-9575f09fbb58","type":"element"},{"id":"b9660760-03c2-451c-84f2-2a77f4f15d2e","type":"element"}]},"label":{"data":[{"id":"ce9aad92-70d0-44a3-9ba4-8bc834d71256","type":"label"},{"id":"4461ceeb-aec7-4ca3-968e-e4b07ae6a597","type":"label"},{"id":"65dc35c7-5c95-4e2d-a2e4-c72051ee1919","type":"label"},{"id":"d50305f2-f8e2-4552-8d2d-6318fbfc8f2c","type":"label"},{"id":"8c058249-ce71-47c5-aa97-282ee37d887e","type":"label"},{"id":"364779ed-a949-4456-ba2c-e7307427f147","type":"label"},{"id":"c76d961c-7dbf-46fb-afb9-4a83cf7dbc05","type":"label"},{"id":"91a080a5-d739-4460-a00a-79cd4ecde5a0","type":"label"}]}},"id":"demos@helium.com","meta":{"created":"2015-09-10T20:50:18.183896Z","updated":"2016-03-01T16:58:38.832646Z"},"type":"organization"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/organization
+  recorded_at: Thu, 13 Oct 2016 14:11:59 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/organization/sensor
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 13 Oct 2016 14:11:59 GMT
+      Server:
+      - Warp/3.2.7
+      transfer-encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"COS MiniDemo Sensor"},"id":"6d3df343-6620-4e96-b1fc-5fd4141b0a8d","meta":{"card":{"id":2},"mac":"6081f9fffe000777","created":"2016-03-01T20:47:19.197875Z","last-seen":"2016-10-13T14:06:47.892834Z","ports":["t","d","_se","b","_b"],"updated":"2016-08-03T11:10:33.3196Z"},"type":"sensor"},{"attributes":{"name":"White
+        Demo"},"id":"9e88aab7-09c1-4a18-a9c1-6e91780d759e","meta":{"card":null,"mac":"6081f9fffe0006d9","created":"2016-06-29T18:50:15.499201Z","last-seen":null,"ports":[],"updated":"2016-08-03T11:10:33.331989Z"},"type":"sensor"},{"attributes":{"name":"Mobile
+        Demo Green 1"},"id":"5be9b35b-6f94-4d9c-8d7a-cafa9b8b6dee","meta":{"card":{"id":5},"mac":"6081f9fffe0006db","created":"2016-04-29T00:04:22.03889Z","last-seen":"2016-06-20T22:56:42.477678Z","ports":["m","b","l","_se","p","t","h","_b"],"updated":"2016-04-29T00:04:22.039087Z"},"type":"sensor"},{"attributes":{"name":"Mobile
+        Demo Green 3"},"id":"94683401-4959-42c7-a38a-92c39a25f34c","meta":{"card":{"id":5},"mac":"6081f9fffe000665","created":"2016-05-25T00:03:38.059788Z","last-seen":"2016-06-24T00:07:02.391306Z","ports":["t","h","l","_se","p","m","b","_b"],"updated":"2016-05-25T00:03:38.059975Z"},"type":"sensor"},{"attributes":{"name":"Mobile
+        Demo Green 2"},"id":"3df4e2e0-0549-4a84-8fb6-442233ce8356","meta":{"card":{"id":5},"mac":"6081f9fffe000695","created":"2016-04-29T00:06:49.344165Z","last-seen":"2016-10-13T13:58:08.838109Z","ports":["h","_b","t","_se","l","p","b","m","Glowfish
+        Alert Level"],"updated":"2016-08-03T11:10:33.315054Z"},"type":"sensor"},{"attributes":{"name":"Helium
+        Green (line powered)"},"id":"32eedf4b-4c64-4708-a670-91af6080ede8","meta":{"card":{"id":5},"mac":"6081f9fffe000475","created":"2016-05-04T18:48:44.352276Z","last-seen":"2016-10-13T14:11:02.74003Z","ports":["t","h","m","b","_b","_e","l","p","_se"],"updated":"2016-08-03T11:10:33.336154Z"},"type":"sensor"},{"attributes":{"name":"Mini
+        Fridge 1.1"},"id":"ec76206d-4ad3-4a42-8fa5-93c1dd06681e","meta":{"card":{"id":2},"mac":"6081f9fffe0006aa","created":"2016-06-14T00:07:58.761507Z","last-seen":"2016-06-29T18:21:04.302722Z","ports":["Glowfish
+        Alert Level","_se","d","_b","b","t"],"updated":"2016-08-03T11:10:33.436857Z"},"type":"sensor"},{"attributes":{"name":"Mini
+        Fridge 4"},"id":"445d5235-646d-4dc9-9bb8-58e21d9ccc44","meta":{"card":{"id":2},"mac":"6081f9fffe000659","created":"2016-01-27T23:41:11.047445Z","last-seen":"2016-10-13T13:14:33.656997Z","ports":["b","d","_se","_b","t"],"updated":"2016-01-27T23:41:11.048766Z"},"type":"sensor"},{"attributes":{"name":"Roamer
+        Sensor"},"id":"33041ecd-5c5e-45aa-80c1-5fa3333ab21f","meta":{"card":null,"mac":"6081f9fffe00064f","created":"2016-03-14T23:48:27.870515Z","last-seen":"2016-03-22T04:56:02.744359Z","ports":["b","d","t"],"updated":"2016-08-03T11:10:33.324651Z"},"type":"sensor"},{"attributes":{"name":"Mini
+        Fridge 3"},"id":"cb396f82-50f8-4758-9c1f-6c441e3277df","meta":{"card":{"id":2},"mac":"6081f9fffe0007eb","created":"2016-01-27T23:24:53.863744Z","last-seen":"2016-10-13T13:58:09.345128Z","ports":["_se","d","t","b","_b","Glowfish
+        Alert Level"],"updated":"2016-08-03T11:10:33.319818Z"},"type":"sensor"},{"attributes":{"name":"test"},"id":"e64ac3b3-518d-4528-90ff-1a1a7ef7c41f","meta":{"card":null,"mac":null,"created":"2016-09-19T01:08:12.000178Z","last-seen":null,"ports":[],"updated":"2016-09-19T01:08:12.000178Z"},"type":"sensor"},{"attributes":{"name":"test"},"id":"9b8b3247-1d2e-41a6-9052-1feff28713d3","meta":{"card":null,"mac":null,"created":"2016-09-19T01:33:42.715958Z","last-seen":null,"ports":[],"updated":"2016-09-19T01:33:42.715958Z"},"type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/organization/sensor
+  recorded_at: Thu, 13 Oct 2016 14:11:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/sensor/element.yml
+++ b/spec/vcr/sensor/element.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/5af6c914-4232-4fda-9e38-1e76597e539b
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Oct 2016 23:11:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '582'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"DC Comm Production"},"relationships":{"metadata":{"data":{"id":"5af6c914-4232-4fda-9e38-1e76597e539b","type":"metadata"}},"element":{"data":{"id":"cb9f0005-5c63-4571-bc46-209f65de9a1c","type":"element"}},"label":{"data":[{"id":"fc92ced7-527b-4c4d-906f-7e421a71c015","type":"label"}]}},"id":"5af6c914-4232-4fda-9e38-1e76597e539b","meta":{"card":{"id":2},"mac":"6081f9fffe000758","created":"2016-05-02T20:40:29.273516Z","last-seen":"2016-10-12T23:08:53.309896Z","ports":["b","d","_se","_b","t"],"updated":"2016-05-04T18:13:19.648998Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/5af6c914-4232-4fda-9e38-1e76597e539b
+  recorded_at: Wed, 12 Oct 2016 23:11:57 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/5af6c914-4232-4fda-9e38-1e76597e539b/element
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 12 Oct 2016 23:11:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '693'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Element 2"},"relationships":{"metadata":{"data":{"id":"cb9f0005-5c63-4571-bc46-209f65de9a1c","type":"metadata"}},"sensor":{"data":[{"id":"5af6c914-4232-4fda-9e38-1e76597e539b","type":"sensor"},{"id":"86c870a7-1a98-4674-82db-4c0c7f0754d9","type":"sensor"},{"id":"b6352700-d41a-4735-b644-a272c511baeb","type":"sensor"},{"id":"20c926f7-a0ad-4551-9a06-de7bc14eea4f","type":"sensor"},{"id":"d6116c24-d523-47e2-b752-38fd78ff5964","type":"sensor"}]}},"id":"cb9f0005-5c63-4571-bc46-209f65de9a1c","meta":{"mac":"6081f9fffe0002f5","created":"2016-05-02T20:33:43.705056Z","last-seen":"2016-10-12T01:14:43.302797Z","updated":"2016-05-02T20:33:43.705056Z"},"type":"element"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/5af6c914-4232-4fda-9e38-1e76597e539b/element
+  recorded_at: Wed, 12 Oct 2016 23:11:57 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
### Element Changes

Replaces the use of [`element?include=sensor`](https://docs.helium.com/api/v1/endpoints.html#get-element-id) in favor of the direct route of [`element/:id/sensor`](https://docs.helium.com/api/v1/endpoints.html#get-element-id) which is preferred moving forward.

### Sensor Changes

Adds support for [`sensor/:id/element`](https://docs.helium.com/api/v1/endpoints.html#get-sensor-id-element) in the form of `sensor.element`.

### Organization Changes

Adds support for the following endpoints:
* [`organization/label`](https://docs.helium.com/api/v1/endpoints.html#get-organization-label)
* [`organization/element`](https://docs.helium.com/api/v1/endpoints.html#get-organization-element)
* [`organization/sensor`](https://docs.helium.com/api/v1/endpoints.html#get-organization-sensor)

### Testing

Tests added for all new endpoints.  Run `rake` to test.