### PR TITLE
Use `sensor/:id/label` to fetch a sensor's labels

### DIFF
--- a/lib/helium/client/sensors.rb
+++ b/lib/helium/client/sensors.rb
@@ -18,6 +18,18 @@ module Helium
         return element
       end
 
+      def sensor_labels(sensor)
+        path = "/sensor/#{sensor.id}/label"
+        response = get(path)
+        labels_data = JSON.parse(response.body)["data"]
+
+        labels = labels_data.map do |label|
+          Label.new(client: self, params: label)
+        end
+
+        return labels
+      end
+
       def sensor_timeseries(sensor, opts = {})
         path = "/sensor/#{sensor.id}/timeseries"
 

--- a/lib/helium/resource.rb
+++ b/lib/helium/resource.rb
@@ -15,7 +15,7 @@ module Helium
 
     class << self
       # NOTE seems a bit out of place to be doing client work here, but it
-      # makes sense for the Eigenclass to be responsable for constructing
+      # makes sense for the Eigenclass to be responsible for constructing
       # instances of its inheriting class.
 
       # Returns all resources

--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -19,14 +19,8 @@ module Helium
       "/sensor?include=label"
     end
 
-    # NOTE: currently this just returns the ids of labels. Once core returns
-    # all label info via includes=label, we can get rid of the
-    # label_relationships stuff
     def labels
-      labels_params = Array(@params.dig('relationships', 'label', 'data'))
-      @labels ||= labels_params.map{ |label_params|
-         Label.new(client: @client, params: label_params)
-      }
+      @client.sensor_labels(self)
     end
 
     def timeseries(opts = {})
@@ -59,8 +53,7 @@ module Helium
         name: name,
         mac: mac,
         ports: ports,
-        last_seen: last_seen,
-        labels: labels
+        last_seen: last_seen
       })
     end
   end

--- a/spec/helium/sensor_spec.rb
+++ b/spec/helium/sensor_spec.rb
@@ -28,12 +28,18 @@ end
 describe Helium::Sensor, '#labels' do
   let(:client) { Helium::Client.new(api_key: API_KEY) }
   let(:sensor) { client.sensor("01d53511-228d-4530-8eaf-74d43c17baa8") }
+  let(:labels) { sensor.labels }
 
   use_cassette 'sensor/labels'
 
-  # NOTE: labels returned currently just have id populated
-  it 'shows labels associated with the sensor' do
-    a_label_id = "f4b9f955-8032-4a03-9c20-10b940137158"
-    expect(sensor.labels.map(&:id)).to include(a_label_id)
+  it 'returns all labels assigned to a sensor' do
+    expect(labels.length).to eq(2)
+  end
+
+  it 'returns fully formed labels' do
+    label = labels.first
+    expect(label.id).to eq("273dc59b-5a69-4247-8675-2970f1f095c6")
+    expect(label.type).to eq("label")
+    expect(label.name).to eq("Label Ladel")
   end
 end

--- a/spec/vcr/sensor/labels.yml
+++ b/spec/vcr/sensor/labels.yml
@@ -22,27 +22,76 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 01 Sep 2016 23:20:30 GMT
-      Server:
-      - Warp/3.2.7
-      Access-Control-Allow-Origin:
-      - "*"
       Access-Control-Allow-Headers:
       - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
-      Airship-Quip:
-      - never breaks eye contact
       Content-Type:
       - application/json
+      Date:
+      - Wed, 19 Oct 2016 22:20:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '623'
+      Connection:
+      - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"John''s Development Isotope with a Brick1"},"relationships":{"metadata":{"data":{"id":"01d53511-228d-4530-8eaf-74d43c17baa8","type":"metadata"}},"element":{"data":null},"label":{"data":[{"id":"f4b9f955-8032-4a03-9c20-10b940137158","type":"label"},{"id":"247a4890-953e-4ac0-ba10-e6395dfb8e34","type":"label"},{"id":"58329ba4-a868-4ef2-b227-4b0bb69c9803","type":"label"},{"id":"4d032014-ec1e-496d-831e-f74595cbb348","type":"label"},{"id":"b2514508-d7e6-4403-9ac7-17e2424eefac","type":"label"},{"id":"f1ea4124-cc22-4dd8-8b9f-5f16883ecdac","type":"label"},{"id":"5f639ef2-8128-48b0-8eef-7b79ee13c856","type":"label"},{"id":"11b0afdc-894e-44a6-822f-8d467505bfb3","type":"label"},{"id":"214b6825-fba6-4f81-8a6a-de484bc2f6bb","type":"label"},{"id":"745ea140-3641-495f-95bb-cd2333c55aea","type":"label"},{"id":"1f412c40-412d-4ce0-9ca0-5bb392b56dad","type":"label"},{"id":"c9f97db3-8abc-40f2-9151-acc1946cf28d","type":"label"},{"id":"b4752f8e-1f3f-48c5-872c-15fdcb660a3e","type":"label"},{"id":"fceb3119-13d2-4e97-843c-1f7ec6708198","type":"label"},{"id":"d28a99b6-0dee-4436-a1cc-03bd689a5866","type":"label"},{"id":"c5a6593d-e58e-42ff-9d2a-6e6e2a87a813","type":"label"},{"id":"935abc8a-eb49-4dbf-a5e5-ae71395055ff","type":"label"},{"id":"968cc881-737e-4bff-bdd6-2af45992fe86","type":"label"}]}},"id":"01d53511-228d-4530-8eaf-74d43c17baa8","meta":{"card":{"id":2},"mac":"6081f9fffe000790","created":"2016-03-29T23:41:29.994176Z","last-seen":"2016-05-17T00:08:57.716681Z","ports":["_b","_se","b","d","h","l","m","p","t"],"updated":"2016-03-29T23:41:29.994404Z"},"type":"sensor"}}'
+      string: '{"data":{"attributes":{"name":"John''s Development Isotope with a Brick1"},"relationships":{"metadata":{"data":{"id":"01d53511-228d-4530-8eaf-74d43c17baa8","type":"metadata"}},"element":{"data":null},"label":{"data":[{"id":"968cc881-737e-4bff-bdd6-2af45992fe86","type":"label"},{"id":"273dc59b-5a69-4247-8675-2970f1f095c6","type":"label"}]}},"id":"01d53511-228d-4530-8eaf-74d43c17baa8","meta":{"card":{"id":2},"mac":"6081f9fffe000790","created":"2016-03-29T23:41:29.994176Z","last-seen":"2016-05-17T00:08:57.716681Z","ports":["b","m","d","p","l","_se","t","_b","h"],"updated":"2016-03-29T23:41:29.994404Z"},"type":"sensor"}}'
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/sensor/01d53511-228d-4530-8eaf-74d43c17baa8
-  recorded_at: Thu, 01 Sep 2016 23:20:30 GMT
+  recorded_at: Wed, 19 Oct 2016 22:20:00 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/01d53511-228d-4530-8eaf-74d43c17baa8/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 19 Oct 2016 22:20:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '993'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"Label Ladel"},"relationships":{"metadata":{"data":{"id":"273dc59b-5a69-4247-8675-2970f1f095c6","type":"metadata"}},"sensor":{"data":[{"id":"492759da-afb0-4d66-a83c-bb001d20c280","type":"sensor"},{"id":"01d53511-228d-4530-8eaf-74d43c17baa8","type":"sensor"}]}},"id":"273dc59b-5a69-4247-8675-2970f1f095c6","meta":{"created":"2016-10-18T17:55:57.374109Z","updated":"2016-10-18T17:55:57.374109Z"},"type":"label"},{"attributes":{"name":"Bricks"},"relationships":{"metadata":{"data":{"id":"968cc881-737e-4bff-bdd6-2af45992fe86","type":"metadata"}},"sensor":{"data":[{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"sensor"},{"id":"c7b11d08-8534-46e4-a14d-0a9306c899b7","type":"sensor"},{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"sensor"},{"id":"01d53511-228d-4530-8eaf-74d43c17baa8","type":"sensor"}]}},"id":"968cc881-737e-4bff-bdd6-2af45992fe86","meta":{"created":"2016-03-30T21:42:22.654635Z","updated":"2016-03-30T21:42:24.772556Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/01d53511-228d-4530-8eaf-74d43c17baa8/label
+  recorded_at: Wed, 19 Oct 2016 22:20:00 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Now that the Helium API supports v1/sensor/:id/label, we use
that rather than the label data in the massive /sensor listing