### PR TITLE
Configurations and DeviceConfigurations

### DIFF
--- a/lib/helium.rb
+++ b/lib/helium.rb
@@ -15,6 +15,8 @@ require "helium/label"
 require "helium/timeseries"
 require "helium/data_point"
 require "helium/element"
+require "helium/configuration"
+require "helium/device_configuration"
 
 module Helium
 end

--- a/lib/helium/client.rb
+++ b/lib/helium/client.rb
@@ -4,6 +4,8 @@ require 'helium/client/organizations'
 require 'helium/client/sensors'
 require 'helium/client/labels'
 require 'helium/client/elements'
+require 'helium/client/configurations'
+require 'helium/client/device_configurations'
 
 module Helium
   class Client
@@ -14,6 +16,9 @@ module Helium
     include Helium::Client::Sensors
     include Helium::Client::Labels
     include Helium::Client::Elements
+    include Helium::Client::Configurations
+    include Helium::Client::DeviceConfigurations
+
 
     API_VERSION = 1
     HOST        = 'api.helium.com'

--- a/lib/helium/client/configurations.rb
+++ b/lib/helium/client/configurations.rb
@@ -21,6 +21,11 @@ module Helium
 
         return device_confs
       end
+
+      # Configurations are immutable, so no updates are available
+      def create_configuration(attributes)
+        Configuration.create(attributes, client: self)
+      end
     end
   end
 end

--- a/lib/helium/client/configurations.rb
+++ b/lib/helium/client/configurations.rb
@@ -1,0 +1,26 @@
+module Helium
+  class Client
+    module Configurations
+
+      def configurations
+        Configuration.all(client: self)
+      end
+
+      def configuration(id)
+        Configuration.find(id, client: self)
+      end
+
+      def config_device_configurations(id)
+        path = "/configuration/#{id}/device-configuration"
+        response = get(path)
+        device_confs_data = JSON.parse(response.body)["data"]
+
+        device_confs = device_confs_data.map do |dc|
+          DeviceConfiguration.new(client: self, params: dc)
+        end
+
+        return device_confs
+      end
+    end
+  end
+end

--- a/lib/helium/client/device_configurations.rb
+++ b/lib/helium/client/device_configurations.rb
@@ -59,7 +59,6 @@ module Helium
         dc = JSON.parse(response.body)["data"]
         return DeviceConfiguration.new(client: self, params: dc)
       end
-
     end
   end
 end

--- a/lib/helium/client/device_configurations.rb
+++ b/lib/helium/client/device_configurations.rb
@@ -22,7 +22,7 @@ module Helium
         path = "/device-configuration/#{device_config.id}/device"
         response = get(path)
         configj = JSON.parse(response.body)["data"]
-        puts "config is: #{configj}"
+
         if configj.dig("type") == "sensor"
           device = Sensor.new(client: self, params: configj)
         elsif configj.dig("type") == "element"

--- a/lib/helium/client/device_configurations.rb
+++ b/lib/helium/client/device_configurations.rb
@@ -1,0 +1,36 @@
+module Helium
+  class Client
+    module DeviceConfigurations
+
+      def device_configurations
+        DeviceConfiguration.all(client: self)
+      end
+
+      def device_configuration(id)
+        DeviceConfiguration.find(id, client: self)
+      end
+
+      def device_configuration_configuration(device_config)
+        path = "/device-configuration/#{device_config.id}/configuration"
+        response = get(path)
+        configj = JSON.parse(response.body)["data"]
+        config = Configuration.new(client: self, params: configj)
+        return config
+      end
+
+      def device_configuration_device(device_config)
+        path = "/device-configuration/#{device_config.id}/device"
+        response = get(path)
+        configj = JSON.parse(response.body)["data"]
+        if configj.type == "sensor"
+          device = Sensor.new(client: self, params: configj)
+        elsif configj.type == "element"
+          device = Element.new(client: self, params: configj)
+        end
+
+        return device
+      end
+
+    end
+  end
+end

--- a/lib/helium/client/device_configurations.rb
+++ b/lib/helium/client/device_configurations.rb
@@ -22,13 +22,42 @@ module Helium
         path = "/device-configuration/#{device_config.id}/device"
         response = get(path)
         configj = JSON.parse(response.body)["data"]
-        if configj.type == "sensor"
+        puts "config is: #{configj}"
+        if configj.dig("type") == "sensor"
           device = Sensor.new(client: self, params: configj)
-        elsif configj.type == "element"
+        elsif configj.dig("type") == "element"
           device = Element.new(client: self, params: configj)
         end
 
         return device
+      end
+
+      def create_device_configuration(device, configuration)
+        path = "/device-configuration"
+
+        body = {
+          data: {
+            type: "device-configuration",
+            relationships: {
+              configuration: {
+                data: {
+                  id: configuration.id,
+                  type: configuration.type
+                }
+              },
+              device: {
+                data: {
+                  id: device.id,
+                  type: device.type
+                }
+              }
+            }
+          }
+        }
+
+        response = post(path, body: body)
+        dc = JSON.parse(response.body)["data"]
+        return DeviceConfiguration.new(client: self, params: dc)
       end
 
     end

--- a/lib/helium/client/elements.rb
+++ b/lib/helium/client/elements.rb
@@ -21,6 +21,14 @@ module Helium
         return sensors
       end
 
+      def element_device_configuration(element)
+        path = "/element/#{element.id}/device-configuration"
+        response = get(path)
+        dc_data = JSON.parse(response.body)["data"]
+        # dc_data is an array, but there will only be one for one
+        return  DeviceConfiguration.new(client: self, params: dc_data[0])
+      end
+
       def element_timeseries(element, opts = {})
         path = "/element/#{element.id}/timeseries"
 

--- a/lib/helium/client/sensors.rb
+++ b/lib/helium/client/sensors.rb
@@ -30,6 +30,14 @@ module Helium
         return labels
       end
 
+      def sensor_device_configuration(sensor)
+        path = "/sensor/#{sensor.id}/device-configuration"
+        response = get(path)
+        dc_data = JSON.parse(response.body)["data"]
+        # dc_data is an array, but there will only be one for one
+        return  DeviceConfiguration.new(client: self, params: dc_data[0])
+      end
+
       def sensor_timeseries(sensor, opts = {})
         path = "/sensor/#{sensor.id}/timeseries"
 

--- a/lib/helium/configuration.rb
+++ b/lib/helium/configuration.rb
@@ -1,0 +1,12 @@
+module Helium
+  class Configuration < Resource
+    attr_reader :settings
+
+    def initialize(opts = {})
+      super(opts)
+      @settings = @params.dig('attributes')
+    end
+
+
+  end
+end

--- a/lib/helium/configuration.rb
+++ b/lib/helium/configuration.rb
@@ -7,6 +7,9 @@ module Helium
       @settings = @params.dig('attributes')
     end
 
+    def device_configurations
+      @client.config_device_configurations(self.id)
+    end
 
   end
 end

--- a/lib/helium/device_configuration.rb
+++ b/lib/helium/device_configuration.rb
@@ -16,9 +16,7 @@ module Helium
     end
 
     def as_json
-      super.merge({
-                    loaded: loaded
-                  })
+      super.merge({ loaded: loaded })
     end
 
   end

--- a/lib/helium/device_configuration.rb
+++ b/lib/helium/device_configuration.rb
@@ -1,0 +1,29 @@
+module Helium
+  class DeviceConfiguration < Resource
+    attr_reader :loaded
+
+    def initialize(opts = {})
+      super(opts)
+      @loaded = @params.dig('meta', 'loaded')
+    end
+
+    def resource_name
+      "device-configuration"
+    end
+
+    def device
+      @client.device_configuration_device(self)
+    end
+
+    def configuration
+      @client.device_configuration_configuration(self)
+    end
+
+    def as_json
+      super.merge({
+                    loaded: loaded
+                  })
+    end
+
+  end
+end

--- a/lib/helium/device_configuration.rb
+++ b/lib/helium/device_configuration.rb
@@ -7,10 +7,6 @@ module Helium
       @loaded = @params.dig('meta', 'loaded')
     end
 
-    def resource_name
-      "device-configuration"
-    end
-
     def device
       @client.device_configuration_device(self)
     end

--- a/lib/helium/element.rb
+++ b/lib/helium/element.rb
@@ -14,6 +14,10 @@ module Helium
       @client.element_sensors(self)
     end
 
+    def device_configuration
+      @client.element_device_configuration(self)
+    end
+
     # @return [DateTime, nil] when the resource was last seen
     def last_seen
       return nil if @last_seen.nil?

--- a/lib/helium/resource.rb
+++ b/lib/helium/resource.rb
@@ -2,6 +2,7 @@ module Helium
   # Abstract base class for Helium Resources returned by the API
   class Resource
     attr_reader :id, :type, :params
+    include Helium::Utils
 
     def initialize(opts = {})
       @client = opts.fetch(:client)
@@ -14,6 +15,8 @@ module Helium
     end
 
     class << self
+      include Helium::Utils
+
       # NOTE seems a bit out of place to be doing client work here, but it
       # makes sense for the Eigenclass to be responsible for constructing
       # instances of its inheriting class.
@@ -73,10 +76,10 @@ module Helium
         return self.new(client: client, params: resource_data)
       end
 
-      #private
+      private
 
       def resource_name
-        self.name.split('::').last.downcase
+        kebab_case(self.name.split('::').last)
       end
     end # << self
 
@@ -158,10 +161,10 @@ module Helium
       as_json.to_json(*options)
     end
 
-    # private
+    private
 
     def resource_name
-      self.class.name.split('::').last.downcase
+      kebab_case(self.class.name.split('::').last)
     end
   end
 end

--- a/lib/helium/resource.rb
+++ b/lib/helium/resource.rb
@@ -73,7 +73,7 @@ module Helium
         return self.new(client: client, params: resource_data)
       end
 
-      private
+      #private
 
       def resource_name
         self.name.split('::').last.downcase
@@ -158,7 +158,7 @@ module Helium
       as_json.to_json(*options)
     end
 
-    private
+    # private
 
     def resource_name
       self.class.name.split('::').last.downcase

--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -23,6 +23,10 @@ module Helium
       @client.sensor_labels(self)
     end
 
+    def device_configuration
+      @client.sensor_device_configuration(self)
+    end
+
     def timeseries(opts = {})
       size        = opts.fetch(:size, 1000)
       port        = opts.fetch(:port, nil)

--- a/lib/helium/utils.rb
+++ b/lib/helium/utils.rb
@@ -4,5 +4,9 @@ module Helium
       return nil if datetime.nil?
       Time.parse(datetime.to_s).utc.iso8601
     end
+
+    def kebab_case(string)
+      string.gsub(/(.)([A-Z])/,'\1-\2').downcase
+    end
   end
 end

--- a/spec/helium/client/configurations_spec.rb
+++ b/spec/helium/client/configurations_spec.rb
@@ -40,7 +40,6 @@ describe Helium::Client, '#configuration' do
 
 end
 
-
 describe Helium::Client, '#configuration_device_configuration' do
   let(:client) { Helium::Client.new(api_key: API_KEY) }
   let(:configuration) { client.configuration("b9dc998e-1926-42ad-a3e0-ba36eea55b45") }

--- a/spec/helium/client/configurations_spec.rb
+++ b/spec/helium/client/configurations_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe Helium::Client, '#configurations' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+
+  use_cassette 'configurations/list'
+
+  it 'is an array of Configurations' do
+    configurations = client.configurations
+    expect(configurations).to be_an(Array)
+    expect(configurations.first).to be_a(Helium::Configuration)
+  end
+
+  it 'returns correctly instantiated configurations' do
+    sensor = client.configurations.first
+    expect(sensor.id).to eq("15c93189-575c-4f26-99a5-bd2991ec89eb")
+  end
+end
+
+describe Helium::Client, '#configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:configuration) { client.configuration("b9dc998e-1926-42ad-a3e0-ba36eea55b45") }
+
+  use_cassette 'configuration/get'
+
+  it 'is a Configuration' do
+    expect(configuration).to be_a(Helium::Configuration)
+  end
+
+  it 'has a type' do
+    expect(configuration.type).to eq("configuration")
+  end
+
+  it 'has settings of proper value' do
+    expect(configuration.settings['somenumber']).to eq(10)
+    expect(configuration.settings['wifipasswd']).to eq("123456789")
+    expect(configuration.settings['jaredtest']).to eq(true)
+  end
+
+
+end
+
+
+describe Helium::Client, '#configuration_device_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:configuration) { client.configuration("b9dc998e-1926-42ad-a3e0-ba36eea55b45") }
+
+  use_cassette 'configuration/device-configuration'
+
+  it 'has device_configurations attached' do
+    dc = configuration.device_configurations
+    expect(dc).to be_an(Array)
+    expect(dc.first.id).to eq("605f7acd-ca93-42e1-8041-eff548db5116")
+  end
+end
+
+describe Helium::Client, '#new_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+
+  use_cassette 'configuration/create'
+
+  it 'creates a new configuration' do
+    new_map = {"rake_test" => true,
+               "a rather large number" => 983247381239812364819233123896123948 }
+    new_configuration = client.create_configuration(new_map)
+    expect(new_configuration).to be_a(Helium::Configuration)
+    expect(new_configuration.settings['rake_test']).to eq(true)
+    expect(new_configuration.settings['a rather large number']).to eq(983247381239812364819233123896123948)
+
+    # verify it's now in the org's configurations
+    all_configurations = client.configurations
+    new_configurations = all_configurations.select{ |s| s.id == new_configuration.id }
+    expect(new_configurations.count).to eq(1)
+  end
+end

--- a/spec/helium/client/device_configurations_spec.rb
+++ b/spec/helium/client/device_configurations_spec.rb
@@ -32,16 +32,29 @@ describe Helium::Client, '#device_configuration' do
   end
 end
 
-describe Helium::Client, '#device_configuration_device' do
+describe Helium::Client, '#device_configuration_device_element' do
   let(:client) { Helium::Client.new(api_key: API_KEY) }
   let(:device_configuration) { client.device_configuration("605f7acd-ca93-42e1-8041-eff548db5116") }
 
-  use_cassette 'device_configuration/device'
+  use_cassette 'device_configuration/device_element'
 
   it 'has a device attached' do
     device = device_configuration.device
     expect(device.id).to eq('d89ed12c-c7bb-4205-a48a-9fe59c96c459')
     expect(device).to be_a(Helium::Element)
+  end
+end
+
+describe Helium::Client, '#device_configuration_device_sensor' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:device_configuration) { client.device_configuration("efb8b88b-0837-42e6-91ba-18ed38d16bbe") }
+
+  use_cassette 'device_configuration/device_sensor'
+
+  it 'has a device attached' do
+    device = device_configuration.device
+    expect(device.id).to eq('aba370be-837d-4b41-bee5-686b0069d874')
+    expect(device).to be_a(Helium::Sensor)
   end
 end
 
@@ -55,5 +68,23 @@ describe Helium::Client, '#device_configuration_configuration' do
     configuration = device_configuration.configuration
     expect(configuration.id).to eq('b9dc998e-1926-42ad-a3e0-ba36eea55b45')
     expect(configuration).to be_a(Helium::Configuration)
+  end
+end
+
+describe Helium::Client, '#new_device_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:configuration) { client.configuration("deb753c7-c7ff-4202-8426-a864d4bd9624")}
+  let(:device) { client.sensor("f928df8f-9cda-4313-9cf7-cffee5d57050") }
+
+  use_cassette 'device_configuration/create'
+
+  it 'creates a new device_configuration' do
+    new_device_configuration = client.create_device_configuration(device, configuration)
+    expect(new_device_configuration).to be_a(Helium::DeviceConfiguration)
+
+    # verify it's now in the org's device_configurations
+    all_device_configurations = client.device_configurations
+    new_device_configurations = all_device_configurations.select{ |s| s.id == new_device_configuration.id }
+    expect(new_device_configurations.count).to eq(1)
   end
 end

--- a/spec/helium/client/device_configurations_spec.rb
+++ b/spec/helium/client/device_configurations_spec.rb
@@ -5,13 +5,13 @@ describe Helium::Client, '#device_configurations' do
 
   use_cassette 'device_configurations/list'
 
-  it 'is an array of Device Configurations' do
+  it 'is an array of device configurations' do
     device_configurations = client.device_configurations
     expect(device_configurations).to be_an(Array)
     expect(device_configurations.first).to be_a(Helium::DeviceConfiguration)
   end
 
-  it 'returns correctly instantiated device_configurations' do
+  it 'returns correctly instantiated device configurations' do
     sensor = client.device_configurations.first
     expect(sensor.id).to eq("605f7acd-ca93-42e1-8041-eff548db5116")
   end
@@ -78,7 +78,7 @@ describe Helium::Client, '#new_device_configuration' do
 
   use_cassette 'device_configuration/create'
 
-  it 'creates a new device_configuration' do
+  it 'creates a new device configuration' do
     new_device_configuration = client.create_device_configuration(device, configuration)
     expect(new_device_configuration).to be_a(Helium::DeviceConfiguration)
 
@@ -86,5 +86,29 @@ describe Helium::Client, '#new_device_configuration' do
     all_device_configurations = client.device_configurations
     new_device_configurations = all_device_configurations.select{ |s| s.id == new_device_configuration.id }
     expect(new_device_configurations.count).to eq(1)
+  end
+end
+
+describe Helium::Client, '#delete_device_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:configuration) { client.configuration("deb753c7-c7ff-4202-8426-a864d4bd9624")}
+  let(:device) { client.sensor("f928df8f-9cda-4313-9cf7-cffee5d57050") }
+
+  use_cassette 'device_configuration/delete'
+
+  it 'deletes a device configuration' do
+    new_dc = client.create_device_configuration(device, configuration)
+    # verify it's now in the org's device_configurations
+    all_dcs = client.device_configurations
+    new_dcs = all_dcs.select{ |s| s.id == new_dc.id }
+    expect(new_dcs.count).to eq(1)
+
+    # Now delete
+    expect(new_dc.destroy).to eq(true)
+
+    # verify it's no longer in the org's device_configurations
+    all_dcs = client.device_configurations
+    new_dcs = all_dcs.select{ |s| s.id == new_dc.id }
+    expect(new_dcs.count).to eq(0)
   end
 end

--- a/spec/helium/client/device_configurations_spec.rb
+++ b/spec/helium/client/device_configurations_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Helium::Client, '#device_configurations' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+
+  use_cassette 'device_configurations/list'
+
+  it 'is an array of Device Configurations' do
+    device_configurations = client.device_configurations
+    expect(device_configurations).to be_an(Array)
+    expect(device_configurations.first).to be_a(Helium::DeviceConfiguration)
+  end
+
+  it 'returns correctly instantiated device_configurations' do
+    sensor = client.device_configurations.first
+    expect(sensor.id).to eq("605f7acd-ca93-42e1-8041-eff548db5116")
+  end
+end
+
+describe Helium::Client, '#device_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:device_configuration) { client.device_configuration("605f7acd-ca93-42e1-8041-eff548db5116") }
+
+  use_cassette 'device_configuration/get'
+
+  it 'is a DeviceConfiguration' do
+    expect(device_configuration).to be_a(Helium::DeviceConfiguration)
+  end
+
+  it 'has a type' do
+    expect(device_configuration.type).to eq("device-configuration")
+  end
+end
+
+describe Helium::Client, '#device_configuration_device' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:device_configuration) { client.device_configuration("605f7acd-ca93-42e1-8041-eff548db5116") }
+
+  use_cassette 'device_configuration/device'
+
+  it 'has a device attached' do
+    device = device_configuration.device
+    expect(device.id).to eq('d89ed12c-c7bb-4205-a48a-9fe59c96c459')
+    expect(device).to be_a(Helium::Element)
+  end
+end
+
+describe Helium::Client, '#device_configuration_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:device_configuration) { client.device_configuration("605f7acd-ca93-42e1-8041-eff548db5116") }
+
+  use_cassette 'device_configuration/configuration'
+
+  it 'has a configuration attached' do
+    configuration = device_configuration.configuration
+    expect(configuration.id).to eq('b9dc998e-1926-42ad-a3e0-ba36eea55b45')
+    expect(configuration).to be_a(Helium::Configuration)
+  end
+end

--- a/spec/helium/client/sensors_spec.rb
+++ b/spec/helium/client/sensors_spec.rb
@@ -106,7 +106,7 @@ describe Helium::Client, '#delete_sensor' do
 
   it 'destroys a virtual sensor' do
     # create a new sensor to destroy
-    new_sensor = client.create_sensor(name: "A Test Sensor")
+    client.create_sensor(name: "A Test Sensor")
 
     # make sure it's in the org sensors first
     all_sensors = client.sensors

--- a/spec/helium/device_configuration_spec.rb
+++ b/spec/helium/device_configuration_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Helium::DeviceConfiguration, '#to_json' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:dc) { client.device_configuration("605f7acd-ca93-42e1-8041-eff548db5116") }
+
+  use_cassette 'device_configuration/to_json'
+
+  it 'is a JSON-encoded string representing the device_configuration' do
+    decoded_json = JSON.parse(dc.to_json)
+    expect(decoded_json["id"]).to eq(dc.id)
+    expect(decoded_json["type"]).to eq(dc.type)
+    expect(decoded_json["loaded"]).to eq (dc.loaded)
+  end
+end

--- a/spec/helium/element_spec.rb
+++ b/spec/helium/element_spec.rb
@@ -63,6 +63,19 @@ describe Helium::Element, '#sensors' do
   end
 end
 
+describe Helium::Element, '#device_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:element) { client.element("56618098-5145-445c-a6db-805eaf37ff51") }
+
+  use_cassette 'element/device_configuration'
+
+  it 'gets a DeviceConfiguration for a Element' do
+    dc = element.device_configuration
+    expect(dc.id).to eq("85a9bbf9-0ff7-4678-b071-03342b6c7f91")
+    expect(dc).to be_a(Helium::DeviceConfiguration)
+  end
+end
+
 describe Helium::Element, '#to_json' do
   let(:client) { instance_double(Helium::Client) }
   let(:element) { described_class.new(client: client, params: ELEMENT_PARAMS) }

--- a/spec/helium/sensor_spec.rb
+++ b/spec/helium/sensor_spec.rb
@@ -43,3 +43,16 @@ describe Helium::Sensor, '#labels' do
     expect(label.name).to eq("Label Ladel")
   end
 end
+
+describe Helium::Sensor, '#device_configuration' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:sensor) { client.sensor("aba370be-837d-4b41-bee5-686b0069d874") }
+
+  use_cassette 'sensor/device_configuration'
+
+  it 'gets a DeviceConfiguration for a Sensor' do
+    dc = sensor.device_configuration
+    expect(dc.id).to eq("efb8b88b-0837-42e6-91ba-18ed38d16bbe")
+    expect(dc).to be_a(Helium::DeviceConfiguration)
+  end
+end

--- a/spec/vcr/configuration/create.yml
+++ b/spec/vcr/configuration/create.yml
@@ -1,0 +1,137 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helium.com/v1/configuration
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"rake_test":true,"a rather large number":983247381239812364819233123896123948},"type":"configuration"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - never breaks eye contact
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 19 Nov 2016 00:38:32 GMT
+      Location:
+      - "/v1/configuration/deb753c7-c7ff-4202-8426-a864d4bd9624"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '272'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"rake_test":true,"a rather large number":983247381239812364819233123896123948},"relationships":{"device-configuration":{"data":[]}},"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","meta":{"created":"2016-11-19T00:38:32.295595Z"},"type":"configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration
+  recorded_at: Sat, 19 Nov 2016 00:38:32 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 19 Nov 2016 00:38:32 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1710'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJkYXRhIjpbeyJhdHRyaWJ1dGVzIjp7InNvbWVudW1iZXIiOiLDpCIsIndp
+        ZmlwYXNzd2QiOiIxMjM0NTY3ODkiLCJqYXJlZHRlc3QiOnRydWV9LCJyZWxh
+        dGlvbnNoaXBzIjp7ImRldmljZS1jb25maWd1cmF0aW9uIjp7ImRhdGEiOltd
+        fX0sImlkIjoiMTVjOTMxODktNTc1Yy00ZjI2LTk5YTUtYmQyOTkxZWM4OWVi
+        IiwibWV0YSI6eyJjcmVhdGVkIjoiMjAxNi0xMS0wOVQyMTo0NDo0MS4wNDEz
+        NjRaIn0sInR5cGUiOiJjb25maWd1cmF0aW9uIn0seyJhdHRyaWJ1dGVzIjp7
+        InNvbWVudW1iZXIiOjEwMDAxLCJzb21lbmV3c2V0dGluZyI6ImZvbyJ9LCJy
+        ZWxhdGlvbnNoaXBzIjp7ImRldmljZS1jb25maWd1cmF0aW9uIjp7ImRhdGEi
+        OltdfX0sImlkIjoiM2EyMjAzZGQtOWRjOS00MmVlLWIwMmMtNGM1YWFkNTYy
+        MDQyIiwibWV0YSI6eyJjcmVhdGVkIjoiMjAxNi0xMS0xOFQyMDowMTo1Ni41
+        MzI1OTJaIn0sInR5cGUiOiJjb25maWd1cmF0aW9uIn0seyJhdHRyaWJ1dGVz
+        Ijp7InNvbWVudW1iZXIiOiJmb28iLCJ3aWZpcGFzc3dkIjoiMTIzNDU2Nzg5
+        IiwiamFyZWR0ZXN0Ijp0cnVlfSwicmVsYXRpb25zaGlwcyI6eyJkZXZpY2Ut
+        Y29uZmlndXJhdGlvbiI6eyJkYXRhIjpbeyJpZCI6Ijg1YTliYmY5LTBmZjct
+        NDY3OC1iMDcxLTAzMzQyYjZjN2Y5MSIsInR5cGUiOiJkZXZpY2UtY29uZmln
+        dXJhdGlvbiJ9LHsiaWQiOiJlZmI4Yjg4Yi0wODM3LTQyZTYtOTFiYS0xOGVk
+        MzhkMTZiYmUiLCJ0eXBlIjoiZGV2aWNlLWNvbmZpZ3VyYXRpb24ifV19fSwi
+        aWQiOiI0NjFiMWUzOC02ZmMyLTQyM2ItOTc0YS1hZTZmNTA0YzQzYTEiLCJt
+        ZXRhIjp7ImNyZWF0ZWQiOiIyMDE2LTExLTA5VDIxOjQzOjAzLjQ3MTQ1NFoi
+        fSwidHlwZSI6ImNvbmZpZ3VyYXRpb24ifSx7ImF0dHJpYnV0ZXMiOnsic29t
+        ZW51bWJlciI6MTEsIndpZmlwYXNzd2QiOiIxMjM0NTY3ODkiLCJqYXJlZHRl
+        c3QiOmZhbHNlfSwicmVsYXRpb25zaGlwcyI6eyJkZXZpY2UtY29uZmlndXJh
+        dGlvbiI6eyJkYXRhIjpbXX19LCJpZCI6Ijk1M2Q2YThlLTg1MGQtNDJlOS04
+        YmEzLTk5NTZmNWYwOTA3YyIsIm1ldGEiOnsiY3JlYXRlZCI6IjIwMTYtMTEt
+        MDlUMjE6NDI6MzAuNjg0MzA3WiJ9LCJ0eXBlIjoiY29uZmlndXJhdGlvbiJ9
+        LHsiYXR0cmlidXRlcyI6eyJzb21lbnVtYmVyIjoxMCwid2lmaXBhc3N3ZCI6
+        IjEyMzQ1Njc4OSIsImphcmVkdGVzdCI6dHJ1ZX0sInJlbGF0aW9uc2hpcHMi
+        OnsiZGV2aWNlLWNvbmZpZ3VyYXRpb24iOnsiZGF0YSI6W3siaWQiOiI2MDVm
+        N2FjZC1jYTkzLTQyZTEtODA0MS1lZmY1NDhkYjUxMTYiLCJ0eXBlIjoiZGV2
+        aWNlLWNvbmZpZ3VyYXRpb24ifV19fSwiaWQiOiJiOWRjOTk4ZS0xOTI2LTQy
+        YWQtYTNlMC1iYTM2ZWVhNTViNDUiLCJtZXRhIjp7ImNyZWF0ZWQiOiIyMDE2
+        LTExLTA5VDIwOjUzOjUxLjE4NjE4M1oifSwidHlwZSI6ImNvbmZpZ3VyYXRp
+        b24ifSx7ImF0dHJpYnV0ZXMiOnsicmFrZV90ZXN0Ijp0cnVlLCJhIHJhdGhl
+        ciBsYXJnZSBudW1iZXIiOjk4MzI0NzM4MTIzOTgxMjM2NDgxOTIzMzEyMzg5
+        NjEyMzk0OH0sInJlbGF0aW9uc2hpcHMiOnsiZGV2aWNlLWNvbmZpZ3VyYXRp
+        b24iOnsiZGF0YSI6W119fSwiaWQiOiJkZWI3NTNjNy1jN2ZmLTQyMDItODQy
+        Ni1hODY0ZDRiZDk2MjQiLCJtZXRhIjp7ImNyZWF0ZWQiOiIyMDE2LTExLTE5
+        VDAwOjM4OjMyLjI5NTU5NVoifSwidHlwZSI6ImNvbmZpZ3VyYXRpb24ifV19
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration
+  recorded_at: Sat, 19 Nov 2016 00:38:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/configuration/device-configuration.yml
+++ b/spec/vcr/configuration/device-configuration.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/configuration/b9dc998e-1926-42ad-a3e0-ba36eea55b45
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 19 Nov 2016 00:21:59 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '327'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"somenumber":10,"wifipasswd":"123456789","jaredtest":true},"relationships":{"device-configuration":{"data":[{"id":"605f7acd-ca93-42e1-8041-eff548db5116","type":"device-configuration"}]}},"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","meta":{"created":"2016-11-09T20:53:51.186183Z"},"type":"configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration/b9dc998e-1926-42ad-a3e0-ba36eea55b45
+  recorded_at: Sat, 19 Nov 2016 00:22:00 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/configuration/b9dc998e-1926-42ad-a3e0-ba36eea55b45/device-configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 19 Nov 2016 00:21:59 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '358'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration/b9dc998e-1926-42ad-a3e0-ba36eea55b45/device-configuration
+  recorded_at: Sat, 19 Nov 2016 00:22:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/configuration/get.yml
+++ b/spec/vcr/configuration/get.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/configuration/b9dc998e-1926-42ad-a3e0-ba36eea55b45
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 19 Nov 2016 00:17:04 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '327'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"somenumber":10,"wifipasswd":"123456789","jaredtest":true},"relationships":{"device-configuration":{"data":[{"id":"605f7acd-ca93-42e1-8041-eff548db5116","type":"device-configuration"}]}},"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","meta":{"created":"2016-11-09T20:53:51.186183Z"},"type":"configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration/b9dc998e-1926-42ad-a3e0-ba36eea55b45
+  recorded_at: Sat, 19 Nov 2016 00:17:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/configurations/list.yml
+++ b/spec/vcr/configurations/list.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 19 Nov 2016 00:12:32 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1446'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJkYXRhIjpbeyJhdHRyaWJ1dGVzIjp7InNvbWVudW1iZXIiOiLDpCIsIndp
+        ZmlwYXNzd2QiOiIxMjM0NTY3ODkiLCJqYXJlZHRlc3QiOnRydWV9LCJyZWxh
+        dGlvbnNoaXBzIjp7ImRldmljZS1jb25maWd1cmF0aW9uIjp7ImRhdGEiOltd
+        fX0sImlkIjoiMTVjOTMxODktNTc1Yy00ZjI2LTk5YTUtYmQyOTkxZWM4OWVi
+        IiwibWV0YSI6eyJjcmVhdGVkIjoiMjAxNi0xMS0wOVQyMTo0NDo0MS4wNDEz
+        NjRaIn0sInR5cGUiOiJjb25maWd1cmF0aW9uIn0seyJhdHRyaWJ1dGVzIjp7
+        InNvbWVudW1iZXIiOjEwMDAxLCJzb21lbmV3c2V0dGluZyI6ImZvbyJ9LCJy
+        ZWxhdGlvbnNoaXBzIjp7ImRldmljZS1jb25maWd1cmF0aW9uIjp7ImRhdGEi
+        OltdfX0sImlkIjoiM2EyMjAzZGQtOWRjOS00MmVlLWIwMmMtNGM1YWFkNTYy
+        MDQyIiwibWV0YSI6eyJjcmVhdGVkIjoiMjAxNi0xMS0xOFQyMDowMTo1Ni41
+        MzI1OTJaIn0sInR5cGUiOiJjb25maWd1cmF0aW9uIn0seyJhdHRyaWJ1dGVz
+        Ijp7InNvbWVudW1iZXIiOiJmb28iLCJ3aWZpcGFzc3dkIjoiMTIzNDU2Nzg5
+        IiwiamFyZWR0ZXN0Ijp0cnVlfSwicmVsYXRpb25zaGlwcyI6eyJkZXZpY2Ut
+        Y29uZmlndXJhdGlvbiI6eyJkYXRhIjpbeyJpZCI6Ijg1YTliYmY5LTBmZjct
+        NDY3OC1iMDcxLTAzMzQyYjZjN2Y5MSIsInR5cGUiOiJkZXZpY2UtY29uZmln
+        dXJhdGlvbiJ9LHsiaWQiOiJlZmI4Yjg4Yi0wODM3LTQyZTYtOTFiYS0xOGVk
+        MzhkMTZiYmUiLCJ0eXBlIjoiZGV2aWNlLWNvbmZpZ3VyYXRpb24ifV19fSwi
+        aWQiOiI0NjFiMWUzOC02ZmMyLTQyM2ItOTc0YS1hZTZmNTA0YzQzYTEiLCJt
+        ZXRhIjp7ImNyZWF0ZWQiOiIyMDE2LTExLTA5VDIxOjQzOjAzLjQ3MTQ1NFoi
+        fSwidHlwZSI6ImNvbmZpZ3VyYXRpb24ifSx7ImF0dHJpYnV0ZXMiOnsic29t
+        ZW51bWJlciI6MTEsIndpZmlwYXNzd2QiOiIxMjM0NTY3ODkiLCJqYXJlZHRl
+        c3QiOmZhbHNlfSwicmVsYXRpb25zaGlwcyI6eyJkZXZpY2UtY29uZmlndXJh
+        dGlvbiI6eyJkYXRhIjpbXX19LCJpZCI6Ijk1M2Q2YThlLTg1MGQtNDJlOS04
+        YmEzLTk5NTZmNWYwOTA3YyIsIm1ldGEiOnsiY3JlYXRlZCI6IjIwMTYtMTEt
+        MDlUMjE6NDI6MzAuNjg0MzA3WiJ9LCJ0eXBlIjoiY29uZmlndXJhdGlvbiJ9
+        LHsiYXR0cmlidXRlcyI6eyJzb21lbnVtYmVyIjoxMCwid2lmaXBhc3N3ZCI6
+        IjEyMzQ1Njc4OSIsImphcmVkdGVzdCI6dHJ1ZX0sInJlbGF0aW9uc2hpcHMi
+        OnsiZGV2aWNlLWNvbmZpZ3VyYXRpb24iOnsiZGF0YSI6W3siaWQiOiI2MDVm
+        N2FjZC1jYTkzLTQyZTEtODA0MS1lZmY1NDhkYjUxMTYiLCJ0eXBlIjoiZGV2
+        aWNlLWNvbmZpZ3VyYXRpb24ifV19fSwiaWQiOiJiOWRjOTk4ZS0xOTI2LTQy
+        YWQtYTNlMC1iYTM2ZWVhNTViNDUiLCJtZXRhIjp7ImNyZWF0ZWQiOiIyMDE2
+        LTExLTA5VDIwOjUzOjUxLjE4NjE4M1oifSwidHlwZSI6ImNvbmZpZ3VyYXRp
+        b24ifV19
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration
+  recorded_at: Sat, 19 Nov 2016 00:12:32 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/configuration.yml
+++ b/spec/vcr/device_configuration/configuration.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:18:20 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '356'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+  recorded_at: Mon, 21 Nov 2016 16:18:20 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116/configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:18:21 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '327'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"somenumber":10,"wifipasswd":"123456789","jaredtest":true},"relationships":{"device-configuration":{"data":[{"id":"605f7acd-ca93-42e1-8041-eff548db5116","type":"device-configuration"}]}},"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","meta":{"created":"2016-11-09T20:53:51.186183Z"},"type":"configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116/configuration
+  recorded_at: Mon, 21 Nov 2016 16:18:21 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/create.yml
+++ b/spec/vcr/device_configuration/create.yml
@@ -1,0 +1,193 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/f928df8f-9cda-4313-9cf7-cffee5d57050
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:32:26 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '869'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Andrew''s Brick-1"},"relationships":{"device-configuration":{"data":[]},"metadata":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"metadata"}},"element":{"data":null},"label":{"data":[{"id":"968cc881-737e-4bff-bdd6-2af45992fe86","type":"label"},{"id":"f0008606-e12e-4a67-af95-bff56ba42eb9","type":"label"},{"id":"f17dee16-df80-4b0a-84bb-3d8969747dbe","type":"label"},{"id":"198d0e28-82e1-4954-a5fc-7b0326a23c6f","type":"label"},{"id":"415e6377-2bc1-46c6-a76c-782e5e7c652d","type":"label"},{"id":"0c228a65-ea5e-4b0d-a321-61009f3647b7","type":"label"}]}},"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","meta":{"card":{"id":5},"mac":"6081f9fffe0007fa","created":"2016-03-30T21:13:50.785417Z","last-seen":"2016-10-04T15:09:56.412569Z","ports":["t","h","p","l","_se","b","m"],"updated":"2016-03-30T21:13:50.785624Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/f928df8f-9cda-4313-9cf7-cffee5d57050
+  recorded_at: Mon, 21 Nov 2016 16:32:26 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/configuration/deb753c7-c7ff-4202-8426-a864d4bd9624
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:32:26 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '272'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"rake_test":true,"a rather large number":983247381239812364819233123896123948},"relationships":{"device-configuration":{"data":[]}},"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","meta":{"created":"2016-11-19T00:38:32.295595Z"},"type":"configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration/deb753c7-c7ff-4202-8426-a864d4bd9624
+  recorded_at: Mon, 21 Nov 2016 16:32:27 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/device-configuration
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"device-configuration","relationships":{"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}},"device":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"sensor"}}}}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:32:26 GMT
+      Location:
+      - "/v1/device-configuration/df795291-ff4f-4598-a59b-e7f1489e7390"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '355'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{},"relationships":{"device":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"sensor"}},"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}}},"id":"df795291-ff4f-4598-a59b-e7f1489e7390","meta":{"loaded":null,"created":"2016-11-21T16:32:27.044479Z"},"type":"device-configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration
+  recorded_at: Mon, 21 Nov 2016 16:32:27 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:32:27 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1400'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"56618098-5145-445c-a6db-805eaf37ff51","type":"element"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"85a9bbf9-0ff7-4678-b071-03342b6c7f91","meta":{"loaded":null,"created":"2016-11-18T23:18:43.576921Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"sensor"}},"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}}},"id":"df795291-ff4f-4598-a59b-e7f1489e7390","meta":{"loaded":null,"created":"2016-11-21T16:32:27.044479Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"sensor"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"efb8b88b-0837-42e6-91ba-18ed38d16bbe","meta":{"loaded":null,"created":"2016-11-18T23:15:57.415719Z"},"type":"device-configuration"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration
+  recorded_at: Mon, 21 Nov 2016 16:32:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/delete.yml
+++ b/spec/vcr/device_configuration/delete.yml
@@ -1,0 +1,283 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/f928df8f-9cda-4313-9cf7-cffee5d57050
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 17:46:45 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '944'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Andrew''s Brick-1"},"relationships":{"device-configuration":{"data":[{"id":"df795291-ff4f-4598-a59b-e7f1489e7390","type":"device-configuration"}]},"metadata":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"metadata"}},"element":{"data":null},"label":{"data":[{"id":"968cc881-737e-4bff-bdd6-2af45992fe86","type":"label"},{"id":"f0008606-e12e-4a67-af95-bff56ba42eb9","type":"label"},{"id":"f17dee16-df80-4b0a-84bb-3d8969747dbe","type":"label"},{"id":"198d0e28-82e1-4954-a5fc-7b0326a23c6f","type":"label"},{"id":"415e6377-2bc1-46c6-a76c-782e5e7c652d","type":"label"},{"id":"0c228a65-ea5e-4b0d-a321-61009f3647b7","type":"label"}]}},"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","meta":{"card":{"id":5},"mac":"6081f9fffe0007fa","created":"2016-03-30T21:13:50.785417Z","last-seen":"2016-10-04T15:09:56.412569Z","ports":["t","h","p","l","_se","b","m"],"updated":"2016-03-30T21:13:50.785624Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/f928df8f-9cda-4313-9cf7-cffee5d57050
+  recorded_at: Mon, 21 Nov 2016 17:46:45 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/configuration/deb753c7-c7ff-4202-8426-a864d4bd9624
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 17:46:45 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '423'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"rake_test":true,"a rather large number":983247381239812364819233123896123948},"relationships":{"device-configuration":{"data":[{"id":"df795291-ff4f-4598-a59b-e7f1489e7390","type":"device-configuration"},{"id":"7923f5ff-f1f2-4f46-ac3f-846bc08defa1","type":"device-configuration"}]}},"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","meta":{"created":"2016-11-19T00:38:32.295595Z"},"type":"configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/configuration/deb753c7-c7ff-4202-8426-a864d4bd9624
+  recorded_at: Mon, 21 Nov 2016 17:46:45 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/device-configuration
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"device-configuration","relationships":{"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}},"device":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"sensor"}}}}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 17:46:45 GMT
+      Location:
+      - "/v1/device-configuration/9830618e-74b3-4591-b388-ef3d8799b3e6"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '355'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{},"relationships":{"device":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"sensor"}},"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}}},"id":"9830618e-74b3-4591-b388-ef3d8799b3e6","meta":{"loaded":null,"created":"2016-11-21T17:46:45.766465Z"},"type":"device-configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration
+  recorded_at: Mon, 21 Nov 2016 17:46:45 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 17:46:45 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1400'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"sensor"}},"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}}},"id":"7923f5ff-f1f2-4f46-ac3f-846bc08defa1","meta":{"loaded":null,"created":"2016-11-21T17:10:57.107772Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"56618098-5145-445c-a6db-805eaf37ff51","type":"element"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"85a9bbf9-0ff7-4678-b071-03342b6c7f91","meta":{"loaded":null,"created":"2016-11-18T23:18:43.576921Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"f928df8f-9cda-4313-9cf7-cffee5d57050","type":"sensor"}},"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}}},"id":"9830618e-74b3-4591-b388-ef3d8799b3e6","meta":{"loaded":null,"created":"2016-11-21T17:46:45.766465Z"},"type":"device-configuration"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration
+  recorded_at: Mon, 21 Nov 2016 17:46:45 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/device-configuration/9830618e-74b3-4591-b388-ef3d8799b3e6
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Mon, 21 Nov 2016 17:46:45 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/9830618e-74b3-4591-b388-ef3d8799b3e6
+  recorded_at: Mon, 21 Nov 2016 17:46:45 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 17:46:45 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1053'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"sensor"}},"configuration":{"data":{"id":"deb753c7-c7ff-4202-8426-a864d4bd9624","type":"configuration"}}},"id":"7923f5ff-f1f2-4f46-ac3f-846bc08defa1","meta":{"loaded":null,"created":"2016-11-21T17:10:57.107772Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"56618098-5145-445c-a6db-805eaf37ff51","type":"element"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"85a9bbf9-0ff7-4678-b071-03342b6c7f91","meta":{"loaded":null,"created":"2016-11-18T23:18:43.576921Z"},"type":"device-configuration"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration
+  recorded_at: Mon, 21 Nov 2016 17:46:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/device.yml
+++ b/spec/vcr/device_configuration/device.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:16:48 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '356'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+  recorded_at: Mon, 21 Nov 2016 16:16:48 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116/device
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - never breaks eye contact
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:16:48 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '272'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Mark Primary Element"},"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","meta":{"mac":"6081f9fffe0001a9","created":"2016-04-27T18:19:06.520815Z","last-seen":"2016-11-15T21:54:58.805949Z","updated":"2016-11-18T01:05:34.685272Z"},"type":"element"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116/device
+  recorded_at: Mon, 21 Nov 2016 16:16:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/device_element.yml
+++ b/spec/vcr/device_configuration/device_element.yml
@@ -27,13 +27,13 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - "$300,000 worth of cows"
+      - blame me if inappropriate
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
       Content-Type:
       - application/json
       Date:
-      - Mon, 21 Nov 2016 16:16:48 GMT
+      - Mon, 21 Nov 2016 16:29:06 GMT
       Server:
       - Warp/3.2.7
       Content-Length:
@@ -46,7 +46,7 @@ http_interactions:
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
-  recorded_at: Mon, 21 Nov 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Nov 2016 16:29:06 GMT
 - request:
     method: get
     uri: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116/device
@@ -74,13 +74,13 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - never breaks eye contact
+      - javascript doesn't have integers
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
       Content-Type:
       - application/json
       Date:
-      - Mon, 21 Nov 2016 16:16:48 GMT
+      - Mon, 21 Nov 2016 16:29:06 GMT
       Server:
       - Warp/3.2.7
       Content-Length:
@@ -93,5 +93,5 @@ http_interactions:
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116/device
-  recorded_at: Mon, 21 Nov 2016 16:16:48 GMT
+  recorded_at: Mon, 21 Nov 2016 16:29:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/device_sensor.yml
+++ b/spec/vcr/device_configuration/device_sensor.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/efb8b88b-0837-42e6-91ba-18ed38d16bbe
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:29:06 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '355'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{},"relationships":{"device":{"data":{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"sensor"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"efb8b88b-0837-42e6-91ba-18ed38d16bbe","meta":{"loaded":null,"created":"2016-11-18T23:15:57.415719Z"},"type":"device-configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/efb8b88b-0837-42e6-91ba-18ed38d16bbe
+  recorded_at: Mon, 21 Nov 2016 16:29:06 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/efb8b88b-0837-42e6-91ba-18ed38d16bbe/device
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - never breaks eye contact
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:29:06 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '311'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"SF Office Brick1 (on Marc''s desk)"},"id":"aba370be-837d-4b41-bee5-686b0069d874","meta":{"card":{"id":5},"mac":"6081f9fffe000478","created":"2016-03-30T20:52:26.314159Z","last-seen":"2016-11-21T02:04:27.307256Z","ports":[],"updated":"2016-11-18T00:02:47.354348Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/efb8b88b-0837-42e6-91ba-18ed38d16bbe/device
+  recorded_at: Mon, 21 Nov 2016 16:29:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/get.yml
+++ b/spec/vcr/device_configuration/get.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:16:48 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '356'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+  recorded_at: Mon, 21 Nov 2016 16:16:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configuration/to_json.yml
+++ b/spec/vcr/device_configuration/to_json.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 18:24:33 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '356'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration/605f7acd-ca93-42e1-8041-eff548db5116
+  recorded_at: Mon, 21 Nov 2016 18:24:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/device_configurations/list.yml
+++ b/spec/vcr/device_configurations/list.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/device-configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:01:48 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1053'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{},"relationships":{"device":{"data":{"id":"d89ed12c-c7bb-4205-a48a-9fe59c96c459","type":"element"}},"configuration":{"data":{"id":"b9dc998e-1926-42ad-a3e0-ba36eea55b45","type":"configuration"}}},"id":"605f7acd-ca93-42e1-8041-eff548db5116","meta":{"loaded":null,"created":"2016-11-09T21:37:31.377437Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"56618098-5145-445c-a6db-805eaf37ff51","type":"element"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"85a9bbf9-0ff7-4678-b071-03342b6c7f91","meta":{"loaded":null,"created":"2016-11-18T23:18:43.576921Z"},"type":"device-configuration"},{"attributes":{},"relationships":{"device":{"data":{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"sensor"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"efb8b88b-0837-42e6-91ba-18ed38d16bbe","meta":{"loaded":null,"created":"2016-11-18T23:15:57.415719Z"},"type":"device-configuration"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/device-configuration
+  recorded_at: Mon, 21 Nov 2016 16:01:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/element/device_configuration.yml
+++ b/spec/vcr/element/device_configuration.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/element/56618098-5145-445c-a6db-805eaf37ff51
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 17:31:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '469'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"SF Office"},"relationships":{"device-configuration":{"data":[{"id":"85a9bbf9-0ff7-4678-b071-03342b6c7f91","type":"device-configuration"}]},"metadata":{"data":{"id":"56618098-5145-445c-a6db-805eaf37ff51","type":"metadata"}},"sensor":{"data":[]}},"id":"56618098-5145-445c-a6db-805eaf37ff51","meta":{"mac":"6081f9fffe00029e","created":"2016-04-27T18:19:06.520815Z","last-seen":null,"updated":"2016-11-18T01:05:34.693805Z"},"type":"element"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/element/56618098-5145-445c-a6db-805eaf37ff51
+  recorded_at: Mon, 21 Nov 2016 17:31:58 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/element/56618098-5145-445c-a6db-805eaf37ff51/device-configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 17:31:58 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '358'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{},"relationships":{"device":{"data":{"id":"56618098-5145-445c-a6db-805eaf37ff51","type":"element"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"85a9bbf9-0ff7-4678-b071-03342b6c7f91","meta":{"loaded":null,"created":"2016-11-18T23:18:43.576921Z"},"type":"device-configuration"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/element/56618098-5145-445c-a6db-805eaf37ff51/device-configuration
+  recorded_at: Mon, 21 Nov 2016 17:31:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/sensor/device_configuration.yml
+++ b/spec/vcr/sensor/device_configuration.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/aba370be-837d-4b41-bee5-686b0069d874
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:54:50 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '1100'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"SF Office Brick1 (on Marc''s desk)"},"relationships":{"device-configuration":{"data":[{"id":"efb8b88b-0837-42e6-91ba-18ed38d16bbe","type":"device-configuration"}]},"metadata":{"data":{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"metadata"}},"element":{"data":{"id":"a56ef1d0-61b9-4bfc-9371-d5349a1270c1","type":"element"}},"label":{"data":[{"id":"d81df823-a7a9-4476-b624-888f9fc56390","type":"label"},{"id":"968cc881-737e-4bff-bdd6-2af45992fe86","type":"label"},{"id":"f0008606-e12e-4a67-af95-bff56ba42eb9","type":"label"},{"id":"f17dee16-df80-4b0a-84bb-3d8969747dbe","type":"label"},{"id":"198d0e28-82e1-4954-a5fc-7b0326a23c6f","type":"label"},{"id":"415e6377-2bc1-46c6-a76c-782e5e7c652d","type":"label"},{"id":"0c228a65-ea5e-4b0d-a321-61009f3647b7","type":"label"}]}},"id":"aba370be-837d-4b41-bee5-686b0069d874","meta":{"card":{"id":5},"mac":"6081f9fffe000478","created":"2016-03-30T20:52:26.314159Z","last-seen":"2016-11-21T02:04:27.307256Z","ports":["_e.info","m","h","t","b","_b","p","_se","l","lr"],"updated":"2016-11-18T00:02:47.354348Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/aba370be-837d-4b41-bee5-686b0069d874
+  recorded_at: Mon, 21 Nov 2016 16:54:50 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/aba370be-837d-4b41-bee5-686b0069d874/device-configuration
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - "<API KEY>"
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 21 Nov 2016 16:54:49 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '357'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{},"relationships":{"device":{"data":{"id":"aba370be-837d-4b41-bee5-686b0069d874","type":"sensor"}},"configuration":{"data":{"id":"461b1e38-6fc2-423b-974a-ae6f504c43a1","type":"configuration"}}},"id":"efb8b88b-0837-42e6-91ba-18ed38d16bbe","meta":{"loaded":null,"created":"2016-11-18T23:15:57.415719Z"},"type":"device-configuration"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/aba370be-837d-4b41-bee5-686b0069d874/device-configuration
+  recorded_at: Mon, 21 Nov 2016 16:54:50 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Adds support for the following endpoints:

```csv
GET	/configuration
POST	/configuration
GET	/configuration/:id
GET	/configuration/:id/device-configuration
GET	/configuration/:id/relationships/device-configuration
GET	/device-configuration
POST	/device-configuration
GET	/device-configuration/:id
DELETE	/device-configuration/:id
GET	/device-configuration/:id/configuration
GET	/device-configuration/:id/device
GET	/device-configuration/:id/relationships/configuration
GET	/device-configuration/:id/relationships/device
GET	/sensor/:id/device-configuration
GET	/sensor/:id/relationships/device-configuration
GET	/element/:id/device-configuration
GET	/element/:id/relationships/device-configuration
```

Relationships can be used any direction given how Configurations / Device Configurations / Devices interact.

Rules:
1. Configurations are immutable, they **cannot be added to or deleted**
1. Configurations are applied to a device (sensor / element) via a DeviceConfiguration
1. There can be exactly one (1) DeviceConfiguration per device
1. Creating a new DeviceConfiguration for a particular device overwrites any prior DeviceConfiguration for that device
1. DeviceConfigurations **can** be deleted

Usage:

Given any device (sensor/element), you can fetch the DeviceConfiguration with `device_configuration`

```ruby
[3] pry(main)> e = client.element("56618098-5145-445c-a6db-805eaf37ff51")
...
[4] pry(main)> device_config = e.device_configuration
=> #<Helium::DeviceConfiguration:0x007ffb71a74738
 @client=<Helium::Client @debug=false>,
 @created_at="2016-11-18T23:18:43.576921Z",
 @id="85a9bbf9-0ff7-4678-b071-03342b6c7f91",
 @loaded=nil,
 @params=
  {"attributes"=>{},
   "relationships"=>{"device"=>{"data"=>{"id"=>"56618098-5145-445c-a6db-805eaf37ff51", "type"=>"element"}}, "configuration"=>{"data"=>{"id"=>"461b1e38-6fc2-423b-974a-ae6f504c43a1", "type"=>"configuration"}}},
   "id"=>"85a9bbf9-0ff7-4678-b071-03342b6c7f91",
   "meta"=>{"loaded"=>nil, "created"=>"2016-11-18T23:18:43.576921Z"},
   "type"=>"device-configuration"},
 @type="device-configuration",
 @updated_at=nil>
```

That DeviceConfiguration can then be inspected for its device
```ruby
[8] pry(main)> device_config.device
=> #<Helium::Element:0x007ffb7311c508
 @client=<Helium::Client @debug=false>,
 @created_at="2016-04-27T18:19:06.520815Z",
 @id="56618098-5145-445c-a6db-805eaf37ff51",
 @last_seen=nil,
 @mac="redacted",
 @name="SF Office",
 @params={"attributes"=>{"name"=>"SF Office"}, "id"=>"56618098-5145-445c-a6db-805eaf37ff51", "meta"=>{"mac"=>"redacted", "created"=>"2016-04-27T18:19:06.520815Z", "last-seen"=>nil, "updated"=>"2016-11-18T01:05:34.693805Z"}, "type"=>"element"},
 @type="element",
 @updated_at="2016-11-18T01:05:34.693805Z">
```

If the device happens to be an element, a `Helium::Element` will be returned, if it is a sensor a `Helium::Sensor` will be returned

Of course all of this would be pointless if we couldn't also see the configuration
```ruby
[9] pry(main)> device_config.configuration
=> #<Helium::Configuration:0x007ffb7302ce68
 @client=<Helium::Client @debug=false>,
 @created_at="2016-11-09T21:43:03.471454Z",
 @id="461b1e38-6fc2-423b-974a-ae6f504c43a1",
 @params={"attributes"=>{"somenumber"=>"foo", "wifipasswd"=>"123456789", "jaredtest"=>true}, "relationships"=>{"device-configuration"=>{"data"=>[{"id"=>"85a9bbf9-0ff7-4678-b071-03342b6c7f91", "type"=>"device-configuration"}]}}, "id"=>"461b1e38-6fc2-423b-974a-ae6f504c43a1", "meta"=>{"created"=>"2016-11-09T21:43:03.471454Z"}, "type"=>"configuration"},
 @settings={"somenumber"=>"foo", "wifipasswd"=>"123456789", "jaredtest"=>true},
 @type="configuration",
 @updated_at=nil>
```

The settings can be fetched for any configuration with the `settings` call
```
[10] pry(main)> device_config.configuration.settings
=> {"somenumber"=>"foo", "wifipasswd"=>"123456789", "jaredtest"=>true}
```

To **create** a Configuration and DeviceConfiguration you simply apply the k/v pairs you want for the configuration

```ruby
some_hash = {"pr_docs" => true,  "some number" => 8675309 }
new_configuration = client.create_configuration(some_hash)
```

From there, to create a DeviceConfiguration you must have both a Configuration and a Device
```ruby
some_config = client.configuration("ffffffff-c7ff-4202-8426-a864d4bd9624")
some_sensor = client.sensor("ffffffff-9cda-4313-9cf7-cffee5d57050")
 new_device_configuration = client.create_device_configuration(some_sensor, some_config)
```

If you want to apply a new configuration to that sensor, once again you can just create a new DeviceConfiguration and it will overwrite the previous one.  You can also delete a DeviceConfiguration by simply calling `new_device_configuration.destroy`

