### PR TITLE
Flexible client initialization

### DIFF
--- a/lib/helium/client.rb
+++ b/lib/helium/client.rb
@@ -20,7 +20,7 @@ module Helium
     include Helium::Client::DeviceConfigurations
 
 
-    API_VERSION = 1
+    API_VERSION = 'v1'
     HOST        = 'api.helium.com'
     PROTOCOL    = 'https'
 
@@ -32,6 +32,7 @@ module Helium
       @api_version = opts.fetch(:api_version, API_VERSION)
       @verify_peer = opts.fetch(:verify_peer, true)
       @debug       = opts.fetch(:debug, false)
+      @headers     = opts.fetch(:headers, {})
     end
 
     def inspect

--- a/lib/helium/client/http.rb
+++ b/lib/helium/client/http.rb
@@ -27,6 +27,10 @@ module Helium
         run(path, :patch, opts)
       end
 
+      def put(path, opts = {})
+        run(path, :put, opts)
+      end
+
       def delete(path)
         response = run(path, :delete)
         response.code == 204
@@ -34,7 +38,7 @@ module Helium
 
       def base_url
         url = "#{PROTOCOL}://#{@api_host}"
-        url += "/v#{@api_version}" if @api_version
+        url += "/#{@api_version}" if @api_version
         url
       end
 
@@ -50,9 +54,11 @@ module Helium
       private
 
       def http_headers
-        BASE_HTTP_HEADERS.merge({
-          'Authorization' => api_key
-        })
+        BASE_HTTP_HEADERS
+          .merge(@headers)
+          .merge({
+            'Authorization' => api_key
+          })
       end
 
       def run(path, method, opts = {})

--- a/spec/helium/client_spec.rb
+++ b/spec/helium/client_spec.rb
@@ -63,3 +63,19 @@ describe Helium::Client do
     end
   end
 end
+
+describe Helium::Client, '#put' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+  let(:request) { instance_double(Typhoeus::Request, response: response) }
+  let(:response) { instance_double(Typhoeus::Response, code: 200) }
+
+  before do
+    allow(Typhoeus::Request).to receive(:new) { request }
+    allow(request).to receive(:run)
+  end
+
+  it 'generates a PUT request' do
+    expect(Typhoeus::Request).to receive(:new)
+    client.put('/a-path')
+  end
+end


### PR DESCRIPTION
This adds some additional flexibility when initializing the client.

It includes:
- No longer assumes that `api_version` is prefixed with `v`
- Allow passing additional headers that will be merged into each request
- Include a `PUT` HTTP method for completeness