### PR TITLE
add device_type as an attribute for sensors and elements

### DIFF
--- a/lib/helium/element.rb
+++ b/lib/helium/element.rb
@@ -1,13 +1,14 @@
 module Helium
   class Element < Resource
-    attr_reader :name, :mac, :last_seen
+    attr_reader :name, :mac, :last_seen, :device_type
 
     def initialize(opts = {})
       super(opts)
 
-      @name      = @params.dig("attributes", "name")
-      @mac       = @params.dig("meta", "mac")
-      @last_seen = @params.dig('meta', 'last-seen')
+      @name        = @params.dig("attributes", "name")
+      @mac         = @params.dig("meta", "mac")
+      @last_seen   = @params.dig('meta', 'last-seen')
+      @device_type = @params.dig('meta', 'device-type')
     end
 
     def sensors
@@ -22,15 +23,6 @@ module Helium
     def last_seen
       return nil if @last_seen.nil?
       @_last_seen ||= DateTime.parse(@last_seen)
-    end
-
-    # TODO can probably generalize this a bit more
-    def as_json
-      super.merge({
-        name: name,
-        mac: mac,
-        last_seen: last_seen
-      })
     end
 
     def timeseries(opts = {})
@@ -49,6 +41,16 @@ module Helium
         aggtype:    aggtype,
         aggsize:    aggsize
       )
+    end
+
+    # TODO can probably generalize this a bit more
+    def as_json
+      super.merge({
+        name: name,
+        mac: mac,
+        last_seen: last_seen,
+        device_type: device_type
+      })
     end
   end
 end

--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -1,14 +1,15 @@
 module Helium
   class Sensor < Resource
-    attr_reader :name, :mac, :ports, :last_seen
+    attr_reader :name, :mac, :ports, :last_seen, :device_type
 
     def initialize(opts = {})
       super(opts)
 
-      @name      = @params.dig('attributes', 'name')
-      @mac       = @params.dig('meta', 'mac')
-      @ports     = @params.dig('meta', 'ports')
-      @last_seen = @params.dig('meta', 'last-seen')
+      @name        = @params.dig('attributes', 'name')
+      @mac         = @params.dig('meta', 'mac')
+      @ports       = @params.dig('meta', 'ports')
+      @last_seen   = @params.dig('meta', 'last-seen')
+      @device_type = @params.dig('meta', 'device-type')
     end
 
     def element
@@ -78,7 +79,8 @@ module Helium
         mac: mac,
         ports: ports,
         last_seen: last_seen,
-        virtual: virtual?
+        virtual: virtual?,
+        device_type: device_type
       })
     end
   end


### PR DESCRIPTION
This exposes the new device-type meta attribute as an attribute of `Helium::Sensor` and `Helium::Element`