### PR TITLE
add/replace/remove labels for a sensor

### DIFF
--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -83,5 +83,35 @@ module Helium
         device_type: device_type
       })
     end
+
+    def add_labels(labels_to_add = [])
+      # There's no first-class support for modifying the labels of a sensor in
+      # the API yet, so we modify each label's relationship to the sensor. Once
+      # this is supported in the API, this can use #add_relationships instead.
+      # Same comment applies for the following 3 functions
+      labels_to_add = Array(labels_to_add)
+      labels_to_add.each do |label|
+        label.add_sensors(self)
+      end
+    end
+
+    def replace_labels(labels_to_replace = [])
+      # To support replacement, we remove this sensor from each label, and then
+      # add it to the specified set
+      labels_to_replace = Array(labels_to_replace)
+      labels.each do |label|
+        label.remove_sensors(self)
+      end
+      labels_to_replace.each do |label|
+        label.add_sensors(self)
+      end
+    end
+
+    def remove_labels(labels_to_remove = [])
+      labels_to_remove = Array(labels_to_remove)
+      labels_to_remove.each do |label|
+        label.remove_sensors(self)
+      end
+    end
   end
 end

--- a/spec/helium/sensor_spec.rb
+++ b/spec/helium/sensor_spec.rb
@@ -44,6 +44,167 @@ describe Helium::Sensor, '#labels' do
   end
 end
 
+describe Helium::Sensor, '#add_labels' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+
+  context "with a single label" do
+    use_cassette 'sensor/add_single_label'
+    it 'adds a single label to a sensor' do
+
+      # create a sensor
+      new_sensor = client.create_sensor(name: "Test Sensor A")
+
+      # create a new label
+      new_label_a = client.create_label(name: "A Test Label")
+
+      # add one label to sensor
+      new_sensor.add_labels(new_label_a)
+
+      # expect the label to be assigned to the label
+      all_label_ids = [new_label_a.id]
+      expect(new_sensor.labels.map(&:id)).to contain_exactly(*all_label_ids)
+
+      # clean up
+      [new_sensor, new_label_a].each(&:destroy)
+    end
+  end
+
+  context "with multiple labels" do
+    use_cassette 'sensor/add_multiple_labels'
+    it 'adds multiple labels to a sensor' do
+
+      # create a sensor
+      new_sensor = client.create_sensor(name: "Test Sensor A")
+
+      # create new labels
+      new_label_a = client.create_label(name: "A Test Label")
+      new_label_b = client.create_label(name: "B Test Label")
+
+      # add labels to sensor
+      new_sensor.add_labels([new_label_a, new_label_b])
+
+      # expect the label to be assigned to the label
+      all_label_ids = [new_label_a.id, new_label_b.id]
+      expect(new_sensor.labels.map(&:id)).to contain_exactly(*all_label_ids)
+
+      # clean up
+      [new_sensor, new_label_a, new_label_b].each(&:destroy)
+    end
+  end
+end
+
+describe Helium::Sensor, '#replace_labels' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+
+  context "with a single label" do
+    use_cassette 'sensor/replace_single_label'
+    it 'replaces a single label associated with a sensor' do
+
+      # create a sensor
+      new_sensor = client.create_sensor(name: "Test Sensor A")
+
+      # create new labels
+      new_label_a = client.create_label(name: "A Test Label")
+      new_label_b = client.create_label(name: "B Test Label")
+
+      # add one label to sensor
+      new_sensor.add_labels(new_label_a)
+
+      # replace the sensor's label
+      new_sensor.replace_labels(new_label_b)
+
+      # expect the label to be assigned to the label
+      all_label_ids = [new_label_b.id]
+      expect(new_sensor.labels.map(&:id)).to contain_exactly(*all_label_ids)
+
+      # clean up
+      [new_sensor, new_label_a, new_label_b].each(&:destroy)
+    end
+  end
+
+  context "with multiple labels" do
+    use_cassette 'sensor/replace_multiple_labels'
+    it 'replaces multiple labels associated with a sensor' do
+
+      # create a sensor
+      new_sensor = client.create_sensor(name: "Test Sensor A")
+
+      # create new labels
+      new_label_a = client.create_label(name: "A Test Label")
+      new_label_b = client.create_label(name: "B Test Label")
+      new_label_c = client.create_label(name: "C Test Label")
+
+      # add label to sensor
+      new_sensor.add_labels(new_label_a)
+      # Replace with labels
+      new_sensor.replace_labels([new_label_b, new_label_c])
+
+      # expect the labels to be assigned to the label
+      all_label_ids = [new_label_b.id, new_label_c.id]
+      expect(new_sensor.labels.map(&:id)).to contain_exactly(*all_label_ids)
+
+      # clean up
+      [new_sensor, new_label_a, new_label_b, new_label_c].each(&:destroy)
+    end
+  end
+end
+
+describe Helium::Sensor, '#remove_labels' do
+  let(:client) { Helium::Client.new(api_key: API_KEY) }
+
+  context "with a single label" do
+    use_cassette 'sensor/remove_single_label'
+    it 'removes a single label to a sensor' do
+
+      # create a sensor
+      new_sensor = client.create_sensor(name: "Test Sensor A")
+
+      # create new labels
+      new_label_a = client.create_label(name: "A Test Label")
+      new_label_b = client.create_label(name: "B Test Label")
+
+      # add labels to sensor
+      new_sensor.add_labels([new_label_a, new_label_b])
+
+      # delete one of the sensor's label
+      new_sensor.remove_labels(new_label_a)
+
+      # expect the label to be assigned to the label
+      all_label_ids = [new_label_b.id]
+      expect(new_sensor.labels.map(&:id)).to contain_exactly(*all_label_ids)
+
+      # clean up
+      [new_sensor, new_label_a, new_label_b].each(&:destroy)
+    end
+  end
+
+  context "with multiple labels" do
+    use_cassette 'sensor/remove_multiple_labels'
+    it 'removes multiple labels associated with a sensor' do
+
+      # create a sensor
+      new_sensor = client.create_sensor(name: "Test Sensor A")
+
+      # create new labels
+      new_label_a = client.create_label(name: "A Test Label")
+      new_label_b = client.create_label(name: "B Test Label")
+      new_label_c = client.create_label(name: "C Test Label")
+
+      # add label to sensor
+      new_sensor.add_labels([new_label_a, new_label_b, new_label_c])
+      # Remove labels
+      new_sensor.remove_labels([new_label_b, new_label_c])
+
+      # expect the labels to be assigned to the label
+      all_label_ids = [new_label_a.id]
+      expect(new_sensor.labels.map(&:id)).to contain_exactly(*all_label_ids)
+
+      # clean up
+      [new_sensor, new_label_a, new_label_b, new_label_c].each(&:destroy)
+    end
+  end
+end
+
 describe Helium::Sensor, '#device_configuration' do
   let(:client) { Helium::Client.new(api_key: API_KEY) }
   let(:sensor) { client.sensor("aba370be-837d-4b41-bee5-686b0069d874") }

--- a/spec/vcr/sensor/add_multiple_labels.yml
+++ b/spec/vcr/sensor/add_multiple_labels.yml
@@ -1,0 +1,421 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helium.com/v1/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"type":"sensor"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Location:
+      - "/v1/sensor/bed6583e-543b-4668-a7cf-ba4d69eee6b1"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '448'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"relationships":{"device-configuration":{"data":[]},"metadata":{"data":{"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","type":"metadata"}},"element":{"data":null},"label":{"data":[]}},"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","meta":{"card":null,"mac":null,"created":"2017-03-03T01:21:55.264894Z","last-seen":null,"ports":[],"device-type":null,"updated":"2017-03-03T01:21:55.264894Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Location:
+      - "/v1/label/981560e1-401d-49f1-afca-f94846eaeee7"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"981560e1-401d-49f1-afca-f94846eaeee7","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"981560e1-401d-49f1-afca-f94846eaeee7","meta":{"created":"2017-03-03T01:21:55.330862Z","updated":"2017-03-03T01:21:55.330862Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Location:
+      - "/v1/label/726904a6-1275-4a8d-84f6-25b077f465b5"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"726904a6-1275-4a8d-84f6-25b077f465b5","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"726904a6-1275-4a8d-84f6-25b077f465b5","meta":{"created":"2017-03-03T01:21:55.395813Z","updated":"2017-03-03T01:21:55.395813Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/981560e1-401d-49f1-afca-f94846eaeee7/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/981560e1-401d-49f1-afca-f94846eaeee7/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/726904a6-1275-4a8d-84f6-25b077f465b5/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/726904a6-1275-4a8d-84f6-25b077f465b5/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/bed6583e-543b-4668-a7cf-ba4d69eee6b1/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '796'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"726904a6-1275-4a8d-84f6-25b077f465b5","type":"metadata"}},"sensor":{"data":[{"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","type":"sensor"}]},"element":{"data":[]}},"id":"726904a6-1275-4a8d-84f6-25b077f465b5","meta":{"created":"2017-03-03T01:21:55.395813Z","updated":"2017-03-03T01:21:55.395813Z"},"type":"label"},{"attributes":{"name":"A
+        Test Label"},"relationships":{"metadata":{"data":{"id":"981560e1-401d-49f1-afca-f94846eaeee7","type":"metadata"}},"sensor":{"data":[{"id":"bed6583e-543b-4668-a7cf-ba4d69eee6b1","type":"sensor"}]},"element":{"data":[]}},"id":"981560e1-401d-49f1-afca-f94846eaeee7","meta":{"created":"2017-03-03T01:21:55.330862Z","updated":"2017-03-03T01:21:55.330862Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/bed6583e-543b-4668-a7cf-ba4d69eee6b1/label
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/sensor/bed6583e-543b-4668-a7cf-ba4d69eee6b1
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/bed6583e-543b-4668-a7cf-ba4d69eee6b1
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/981560e1-401d-49f1-afca-f94846eaeee7
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/981560e1-401d-49f1-afca-f94846eaeee7
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/726904a6-1275-4a8d-84f6-25b077f465b5
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:21:55 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/726904a6-1275-4a8d-84f6-25b077f465b5
+  recorded_at: Fri, 03 Mar 2017 01:21:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/sensor/add_single_label.yml
+++ b/spec/vcr/sensor/add_single_label.yml
@@ -1,0 +1,281 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helium.com/v1/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"type":"sensor"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:17:35 GMT
+      Location:
+      - "/v1/sensor/3d6d55a0-904a-4cbf-9264-01d0e073341a"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '448'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"relationships":{"device-configuration":{"data":[]},"metadata":{"data":{"id":"3d6d55a0-904a-4cbf-9264-01d0e073341a","type":"metadata"}},"element":{"data":null},"label":{"data":[]}},"id":"3d6d55a0-904a-4cbf-9264-01d0e073341a","meta":{"card":null,"mac":null,"created":"2017-03-03T01:17:35.337243Z","last-seen":null,"ports":[],"device-type":null,"updated":"2017-03-03T01:17:35.337243Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor
+  recorded_at: Fri, 03 Mar 2017 01:17:35 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:17:34 GMT
+      Location:
+      - "/v1/label/75f9c183-5f55-416e-9932-3a9480f8a144"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '338'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"75f9c183-5f55-416e-9932-3a9480f8a144","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"75f9c183-5f55-416e-9932-3a9480f8a144","meta":{"created":"2017-03-03T01:17:35.40133Z","updated":"2017-03-03T01:17:35.40133Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:17:35 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/75f9c183-5f55-416e-9932-3a9480f8a144/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"3d6d55a0-904a-4cbf-9264-01d0e073341a","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:17:35 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"3d6d55a0-904a-4cbf-9264-01d0e073341a","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/75f9c183-5f55-416e-9932-3a9480f8a144/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:17:35 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/3d6d55a0-904a-4cbf-9264-01d0e073341a/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:17:34 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '401'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"75f9c183-5f55-416e-9932-3a9480f8a144","type":"metadata"}},"sensor":{"data":[{"id":"3d6d55a0-904a-4cbf-9264-01d0e073341a","type":"sensor"}]},"element":{"data":[]}},"id":"75f9c183-5f55-416e-9932-3a9480f8a144","meta":{"created":"2017-03-03T01:17:35.40133Z","updated":"2017-03-03T01:17:35.40133Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/3d6d55a0-904a-4cbf-9264-01d0e073341a/label
+  recorded_at: Fri, 03 Mar 2017 01:17:35 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/sensor/3d6d55a0-904a-4cbf-9264-01d0e073341a
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:17:35 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/3d6d55a0-904a-4cbf-9264-01d0e073341a
+  recorded_at: Fri, 03 Mar 2017 01:17:35 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/75f9c183-5f55-416e-9932-3a9480f8a144
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:17:35 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/75f9c183-5f55-416e-9932-3a9480f8a144
+  recorded_at: Fri, 03 Mar 2017 01:17:35 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/sensor/remove_multiple_labels.yml
+++ b/spec/vcr/sensor/remove_multiple_labels.yml
@@ -1,0 +1,653 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helium.com/v1/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"type":"sensor"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:55 GMT
+      Location:
+      - "/v1/sensor/f238575b-29aa-4add-bc42-bd208c939ac0"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '448'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"relationships":{"device-configuration":{"data":[]},"metadata":{"data":{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"metadata"}},"element":{"data":null},"label":{"data":[]}},"id":"f238575b-29aa-4add-bc42-bd208c939ac0","meta":{"card":null,"mac":null,"created":"2017-03-03T01:26:56.716739Z","last-seen":null,"ports":[],"device-type":null,"updated":"2017-03-03T01:26:56.716739Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:56 GMT
+      Location:
+      - "/v1/label/e2061cd8-af50-40b4-a010-fd7711dc6108"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '338'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"e2061cd8-af50-40b4-a010-fd7711dc6108","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"e2061cd8-af50-40b4-a010-fd7711dc6108","meta":{"created":"2017-03-03T01:26:56.78372Z","updated":"2017-03-03T01:26:56.78372Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:55 GMT
+      Location:
+      - "/v1/label/585e5c5d-962f-43b9-9758-a3a5a004ea3d"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"585e5c5d-962f-43b9-9758-a3a5a004ea3d","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"585e5c5d-962f-43b9-9758-a3a5a004ea3d","meta":{"created":"2017-03-03T01:26:56.851934Z","updated":"2017-03-03T01:26:56.851934Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"C Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Location:
+      - "/v1/label/1a897d78-35dd-4664-9e03-b1877c19d81c"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"C Test Label"},"relationships":{"metadata":{"data":{"id":"1a897d78-35dd-4664-9e03-b1877c19d81c","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"1a897d78-35dd-4664-9e03-b1877c19d81c","meta":{"created":"2017-03-03T01:26:57.037084Z","updated":"2017-03-03T01:26:57.037084Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/e2061cd8-af50-40b4-a010-fd7711dc6108/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/e2061cd8-af50-40b4-a010-fd7711dc6108/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/585e5c5d-962f-43b9-9758-a3a5a004ea3d/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/585e5c5d-962f-43b9-9758-a3a5a004ea3d/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/1a897d78-35dd-4664-9e03-b1877c19d81c/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/1a897d78-35dd-4664-9e03-b1877c19d81c/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/585e5c5d-962f-43b9-9758-a3a5a004ea3d/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - never breaks eye contact
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '11'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/585e5c5d-962f-43b9-9758-a3a5a004ea3d/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/1a897d78-35dd-4664-9e03-b1877c19d81c/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '11'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/1a897d78-35dd-4664-9e03-b1877c19d81c/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/f238575b-29aa-4add-bc42-bd208c939ac0/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '401'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"e2061cd8-af50-40b4-a010-fd7711dc6108","type":"metadata"}},"sensor":{"data":[{"id":"f238575b-29aa-4add-bc42-bd208c939ac0","type":"sensor"}]},"element":{"data":[]}},"id":"e2061cd8-af50-40b4-a010-fd7711dc6108","meta":{"created":"2017-03-03T01:26:56.78372Z","updated":"2017-03-03T01:26:56.78372Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/f238575b-29aa-4add-bc42-bd208c939ac0/label
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/sensor/f238575b-29aa-4add-bc42-bd208c939ac0
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/f238575b-29aa-4add-bc42-bd208c939ac0
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/e2061cd8-af50-40b4-a010-fd7711dc6108
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/e2061cd8-af50-40b4-a010-fd7711dc6108
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/585e5c5d-962f-43b9-9758-a3a5a004ea3d
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/585e5c5d-962f-43b9-9758-a3a5a004ea3d
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/1a897d78-35dd-4664-9e03-b1877c19d81c
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:26:57 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/1a897d78-35dd-4664-9e03-b1877c19d81c
+  recorded_at: Fri, 03 Mar 2017 01:26:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/sensor/remove_single_label.yml
+++ b/spec/vcr/sensor/remove_single_label.yml
@@ -1,0 +1,467 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helium.com/v1/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"type":"sensor"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:55 GMT
+      Location:
+      - "/v1/sensor/4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '448'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"relationships":{"device-configuration":{"data":[]},"metadata":{"data":{"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","type":"metadata"}},"element":{"data":null},"label":{"data":[]}},"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","meta":{"card":null,"mac":null,"created":"2017-03-03T01:26:55.915833Z","last-seen":null,"ports":[],"device-type":null,"updated":"2017-03-03T01:26:55.915833Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:55 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - 'WARNING: ulimit -n is 1024'
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:56 GMT
+      Location:
+      - "/v1/label/b168f512-8455-4e3d-8e6b-482c4c7f00ed"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"b168f512-8455-4e3d-8e6b-482c4c7f00ed","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"b168f512-8455-4e3d-8e6b-482c4c7f00ed","meta":{"created":"2017-03-03T01:26:55.997745Z","updated":"2017-03-03T01:26:55.997745Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:55 GMT
+      Location:
+      - "/v1/label/c8ca7cd4-34fb-4d7b-8610-66978b3b1995"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"c8ca7cd4-34fb-4d7b-8610-66978b3b1995","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"c8ca7cd4-34fb-4d7b-8610-66978b3b1995","meta":{"created":"2017-03-03T01:26:56.064564Z","updated":"2017-03-03T01:26:56.064564Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/b168f512-8455-4e3d-8e6b-482c4c7f00ed/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:56 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/b168f512-8455-4e3d-8e6b-482c4c7f00ed/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/c8ca7cd4-34fb-4d7b-8610-66978b3b1995/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - never breaks eye contact
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:55 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/c8ca7cd4-34fb-4d7b-8610-66978b3b1995/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/b168f512-8455-4e3d-8e6b-482c4c7f00ed/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:56 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '11'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/b168f512-8455-4e3d-8e6b-482c4c7f00ed/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:26:55 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '403'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"c8ca7cd4-34fb-4d7b-8610-66978b3b1995","type":"metadata"}},"sensor":{"data":[{"id":"4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215","type":"sensor"}]},"element":{"data":[]}},"id":"c8ca7cd4-34fb-4d7b-8610-66978b3b1995","meta":{"created":"2017-03-03T01:26:56.064564Z","updated":"2017-03-03T01:26:56.064564Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215/label
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/sensor/4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:26:56 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/4b6bcb0a-99dd-4c1d-aefd-d02cc0e6a215
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/b168f512-8455-4e3d-8e6b-482c4c7f00ed
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:26:55 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/b168f512-8455-4e3d-8e6b-482c4c7f00ed
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/c8ca7cd4-34fb-4d7b-8610-66978b3b1995
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:26:56 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/c8ca7cd4-34fb-4d7b-8610-66978b3b1995
+  recorded_at: Fri, 03 Mar 2017 01:26:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/sensor/replace_multiple_labels.yml
+++ b/spec/vcr/sensor/replace_multiple_labels.yml
@@ -1,0 +1,654 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helium.com/v1/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"type":"sensor"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Location:
+      - "/v1/sensor/5d9f5d9b-02cb-4350-9dc8-aabb011092d3"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '448'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"relationships":{"device-configuration":{"data":[]},"metadata":{"data":{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"metadata"}},"element":{"data":null},"label":{"data":[]}},"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","meta":{"card":null,"mac":null,"created":"2017-03-03T01:24:00.387955Z","last-seen":null,"ports":[],"device-type":null,"updated":"2017-03-03T01:24:00.387955Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Location:
+      - "/v1/label/52375204-c1cd-42c4-82cc-252c09c54c9c"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"52375204-c1cd-42c4-82cc-252c09c54c9c","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"52375204-c1cd-42c4-82cc-252c09c54c9c","meta":{"created":"2017-03-03T01:24:00.456976Z","updated":"2017-03-03T01:24:00.456976Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - blame me if inappropriate
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Location:
+      - "/v1/label/41120022-92f5-4e95-ae60-06010bb1dbc0"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"41120022-92f5-4e95-ae60-06010bb1dbc0","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"41120022-92f5-4e95-ae60-06010bb1dbc0","meta":{"created":"2017-03-03T01:24:00.523202Z","updated":"2017-03-03T01:24:00.523202Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"C Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Location:
+      - "/v1/label/f61d5c17-21a3-41c8-91a9-31f488edcb88"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '338'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"C Test Label"},"relationships":{"metadata":{"data":{"id":"f61d5c17-21a3-41c8-91a9-31f488edcb88","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"f61d5c17-21a3-41c8-91a9-31f488edcb88","meta":{"created":"2017-03-03T01:24:00.58959Z","updated":"2017-03-03T01:24:00.58959Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/52375204-c1cd-42c4-82cc-252c09c54c9c/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/52375204-c1cd-42c4-82cc-252c09c54c9c/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/5d9f5d9b-02cb-4350-9dc8-aabb011092d3/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - javascript doesn't have integers
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '403'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"52375204-c1cd-42c4-82cc-252c09c54c9c","type":"metadata"}},"sensor":{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]},"element":{"data":[]}},"id":"52375204-c1cd-42c4-82cc-252c09c54c9c","meta":{"created":"2017-03-03T01:24:00.456976Z","updated":"2017-03-03T01:24:00.456976Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/5d9f5d9b-02cb-4350-9dc8-aabb011092d3/label
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/52375204-c1cd-42c4-82cc-252c09c54c9c/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '11'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/52375204-c1cd-42c4-82cc-252c09c54c9c/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/41120022-92f5-4e95-ae60-06010bb1dbc0/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/41120022-92f5-4e95-ae60-06010bb1dbc0/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:24:00 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/f61d5c17-21a3-41c8-91a9-31f488edcb88/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/f61d5c17-21a3-41c8-91a9-31f488edcb88/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:24:01 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/5d9f5d9b-02cb-4350-9dc8-aabb011092d3/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - never breaks eye contact
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '794'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"41120022-92f5-4e95-ae60-06010bb1dbc0","type":"metadata"}},"sensor":{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]},"element":{"data":[]}},"id":"41120022-92f5-4e95-ae60-06010bb1dbc0","meta":{"created":"2017-03-03T01:24:00.523202Z","updated":"2017-03-03T01:24:00.523202Z"},"type":"label"},{"attributes":{"name":"C
+        Test Label"},"relationships":{"metadata":{"data":{"id":"f61d5c17-21a3-41c8-91a9-31f488edcb88","type":"metadata"}},"sensor":{"data":[{"id":"5d9f5d9b-02cb-4350-9dc8-aabb011092d3","type":"sensor"}]},"element":{"data":[]}},"id":"f61d5c17-21a3-41c8-91a9-31f488edcb88","meta":{"created":"2017-03-03T01:24:00.58959Z","updated":"2017-03-03T01:24:00.58959Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/5d9f5d9b-02cb-4350-9dc8-aabb011092d3/label
+  recorded_at: Fri, 03 Mar 2017 01:24:01 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/sensor/5d9f5d9b-02cb-4350-9dc8-aabb011092d3
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/5d9f5d9b-02cb-4350-9dc8-aabb011092d3
+  recorded_at: Fri, 03 Mar 2017 01:24:01 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/52375204-c1cd-42c4-82cc-252c09c54c9c
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/52375204-c1cd-42c4-82cc-252c09c54c9c
+  recorded_at: Fri, 03 Mar 2017 01:24:01 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/41120022-92f5-4e95-ae60-06010bb1dbc0
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:24:01 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/41120022-92f5-4e95-ae60-06010bb1dbc0
+  recorded_at: Fri, 03 Mar 2017 01:24:01 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/f61d5c17-21a3-41c8-91a9-31f488edcb88
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:24:00 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/f61d5c17-21a3-41c8-91a9-31f488edcb88
+  recorded_at: Fri, 03 Mar 2017 01:24:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr/sensor/replace_single_label.yml
+++ b/spec/vcr/sensor/replace_single_label.yml
@@ -1,0 +1,514 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.helium.com/v1/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"type":"sensor"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Location:
+      - "/v1/sensor/f1a30539-2c33-4ef5-960f-82c0c676d5a1"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '448'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"Test Sensor A"},"relationships":{"device-configuration":{"data":[]},"metadata":{"data":{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"metadata"}},"element":{"data":null},"label":{"data":[]}},"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","meta":{"card":null,"mac":null,"created":"2017-03-03T01:23:06.697917Z","last-seen":null,"ports":[],"device-type":null,"updated":"2017-03-03T01:23:06.697917Z"},"type":"sensor"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor
+  recorded_at: Fri, 03 Mar 2017 01:23:06 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - firm pat on the back
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Location:
+      - "/v1/label/13336cec-05a2-4205-a0c6-bda2f6bb9e1f"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"13336cec-05a2-4205-a0c6-bda2f6bb9e1f","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"13336cec-05a2-4205-a0c6-bda2f6bb9e1f","meta":{"created":"2017-03-03T01:23:06.899775Z","updated":"2017-03-03T01:23:06.899775Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:23:06 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"type":"label"}}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Location:
+      - "/v1/label/b7dc8744-7429-44d7-aefa-1bc694a01e9a"
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '340'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"b7dc8744-7429-44d7-aefa-1bc694a01e9a","type":"metadata"}},"sensor":{"data":[]},"element":{"data":[]}},"id":"b7dc8744-7429-44d7-aefa-1bc694a01e9a","meta":{"created":"2017-03-03T01:23:06.967783Z","updated":"2017-03-03T01:23:06.967783Z"},"type":"label"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label
+  recorded_at: Fri, 03 Mar 2017 01:23:06 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/13336cec-05a2-4205-a0c6-bda2f6bb9e1f/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/13336cec-05a2-4205-a0c6-bda2f6bb9e1f/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/f1a30539-2c33-4ef5-960f-82c0c676d5a1/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - never breaks eye contact
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '403'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"A Test Label"},"relationships":{"metadata":{"data":{"id":"13336cec-05a2-4205-a0c6-bda2f6bb9e1f","type":"metadata"}},"sensor":{"data":[{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"sensor"}]},"element":{"data":[]}},"id":"13336cec-05a2-4205-a0c6-bda2f6bb9e1f","meta":{"created":"2017-03-03T01:23:06.899775Z","updated":"2017-03-03T01:23:06.899775Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/f1a30539-2c33-4ef5-960f-82c0c676d5a1/label
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/13336cec-05a2-4205-a0c6-bda2f6bb9e1f/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '11'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/13336cec-05a2-4205-a0c6-bda2f6bb9e1f/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+- request:
+    method: post
+    uri: https://api.helium.com/v1/label/b7dc8744-7429-44d7-aefa-1bc694a01e9a/relationships/sensor
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"sensor"}]}'
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - evacuation not done in time
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11,o20,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '72'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"sensor"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/b7dc8744-7429-44d7-aefa-1bc694a01e9a/relationships/sensor
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/sensor/f1a30539-2c33-4ef5-960f-82c0c676d5a1/label
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '403'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"attributes":{"name":"B Test Label"},"relationships":{"metadata":{"data":{"id":"b7dc8744-7429-44d7-aefa-1bc694a01e9a","type":"metadata"}},"sensor":{"data":[{"id":"f1a30539-2c33-4ef5-960f-82c0c676d5a1","type":"sensor"}]},"element":{"data":[]}},"id":"b7dc8744-7429-44d7-aefa-1bc694a01e9a","meta":{"created":"2017-03-03T01:23:06.967783Z","updated":"2017-03-03T01:23:06.967783Z"},"type":"label"}]}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/f1a30539-2c33-4ef5-960f-82c0c676d5a1/label
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/sensor/f1a30539-2c33-4ef5-960f-82c0c676d5a1
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - "$300,000 worth of cows"
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/sensor/f1a30539-2c33-4ef5-960f-82c0c676d5a1
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/13336cec-05a2-4205-a0c6-bda2f6bb9e1f
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - RB_GC_GUARD
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/13336cec-05a2-4205-a0c6-bda2f6bb9e1f
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+- request:
+    method: delete
+    uri: https://api.helium.com/v1/label/b7dc8744-7429-44d7-aefa-1bc694a01e9a
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - shut it down
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
+      Date:
+      - Fri, 03 Mar 2017 01:23:06 GMT
+      Server:
+      - Warp/3.2.7
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/label/b7dc8744-7429-44d7-aefa-1bc694a01e9a
+  recorded_at: Fri, 03 Mar 2017 01:23:07 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Add `add/replace/remove_labels` for `sensor`. Unfortunately, there's not (yet) first-class support to modifying the labels of a single sensor. The implementation of these methods instead makes a call for each of the `n` labels to add the sensor. Less than ideal, but the only way to manage it currently. Once we do have support for this operation in the API (and there is an outstanding story), we can transparently replace the implementation using the `x_relationships` methods on `Collection`.