### PR TITLE
Add chaining for functions modifying senor labels

### DIFF
--- a/lib/helium/sensor.rb
+++ b/lib/helium/sensor.rb
@@ -93,6 +93,7 @@ module Helium
       labels_to_add.each do |label|
         label.add_sensors(self)
       end
+      self
     end
 
     def replace_labels(labels_to_replace = [])
@@ -105,6 +106,7 @@ module Helium
       labels_to_replace.each do |label|
         label.add_sensors(self)
       end
+      self
     end
 
     def remove_labels(labels_to_remove = [])
@@ -112,6 +114,7 @@ module Helium
       labels_to_remove.each do |label|
         label.remove_sensors(self)
       end
+      self
     end
   end
 end


### PR DESCRIPTION
I neglected to return `self` for the `add/replace/remove_labels` methods in Sensor.

No need to cut a release for this, it can go out it the next one.