### PR TITLE
Fix Resources#update with new instance client

### DIFF
--- a/lib/helium/resource.rb
+++ b/lib/helium/resource.rb
@@ -103,7 +103,7 @@ module Helium
       response = @client.patch(resource_path, body: body)
       resource_data = JSON.parse(response.body)["data"]
 
-      return self.class.new(client: self, params: resource_data)
+      return self.class.new(client: @client, params: resource_data)
     end
 
     # Deletes the Resource


### PR DESCRIPTION
The method `Resource#update` was returning a new instance with the `client` attribute set to the calling object, instead of an actual client.