### PR TITLE
Packages in API can now be named

### DIFF
--- a/spec/helium/client/helium_script_spec.rb
+++ b/spec/helium/client/helium_script_spec.rb
@@ -135,8 +135,6 @@ describe Helium::Client, '#create_package' do
   it 'creates a new Package' do
     expect(@package).to be_a(Helium::Package)
     expect(@package).to respond_to(:id)
-    # [2017-05-18] Bug in the API currently prevents setting name
-    pending("API bug prevents setting name")
     expect(@package.name).to eq('test package')
   end
 

--- a/spec/helium/helium_script_spec.rb
+++ b/spec/helium/helium_script_spec.rb
@@ -93,7 +93,6 @@ describe Helium::Package do
   end
 
   it 'has a name' do
-    pending("API bug prevents setting name")
     expect(@package.name).to eq('Test Package')
   end
 

--- a/spec/vcr/helium_script/package.yml
+++ b/spec/vcr/helium_script/package.yml
@@ -27,15 +27,15 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - evacuation not done in time
+      - shut it down
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
       Content-Type:
       - application/json;charset=utf8
       Date:
-      - Wed, 19 Apr 2017 19:47:33 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Location:
-      - "/v1/script/7026db5a-669a-4433-b44b-48fd0092d93d"
+      - "/v1/script/3a6ce3bf-8600-4791-87cb-5a8491bd8fa0"
       Server:
       - Warp/3.2.7
       Content-Length:
@@ -44,11 +44,11 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"7026db5a-669a-4433-b44b-48fd0092d93d","type":"metadata"}}},"id":"7026db5a-669a-4433-b44b-48fd0092d93d","meta":{"created":"2017-04-19T19:47:34.016069Z","digest":"106505101da9e8d279dc688ec1a2cda647debda8d0112553885add44ba039391"},"type":"script"}}'
+      string: '{"data":{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"3a6ce3bf-8600-4791-87cb-5a8491bd8fa0","type":"metadata"}}},"id":"3a6ce3bf-8600-4791-87cb-5a8491bd8fa0","meta":{"created":"2017-04-25T22:25:36.629284Z","digest":"106505101da9e8d279dc688ec1a2cda647debda8d0112553885add44ba039391"},"type":"script"}}'
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/script
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 - request:
     method: post
     uri: https://api.helium.com/v1/library
@@ -76,15 +76,15 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - blame me if inappropriate
+      - firm pat on the back
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
       Content-Type:
       - application/json;charset=utf8
       Date:
-      - Wed, 19 Apr 2017 19:47:33 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Location:
-      - "/v1/library/16ba438f-6853-4870-8a92-2699b82c76f9"
+      - "/v1/library/3d1bcfaa-c882-46e4-9812-6900f5871073"
       Server:
       - Warp/3.2.7
       Content-Length:
@@ -93,17 +93,17 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"16ba438f-6853-4870-8a92-2699b82c76f9","type":"metadata"}}},"id":"16ba438f-6853-4870-8a92-2699b82c76f9","meta":{"created":"2017-04-19T19:47:34.160265Z","digest":"500800f8193f61c59a5e1a085971a23a7bc2473529fddf9cdd46b48096f387f3"},"type":"library"}}'
+      string: '{"data":{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"3d1bcfaa-c882-46e4-9812-6900f5871073","type":"metadata"}}},"id":"3d1bcfaa-c882-46e4-9812-6900f5871073","meta":{"created":"2017-04-25T22:25:36.704877Z","digest":"500800f8193f61c59a5e1a085971a23a7bc2473529fddf9cdd46b48096f387f3"},"type":"library"}}'
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/library
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 - request:
     method: post
     uri: https://api.helium.com/v1/package
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"Test Package"},"type":"package","relationships":{"script":{"data":{"id":"7026db5a-669a-4433-b44b-48fd0092d93d","type":"script"}},"library":{"data":[{"id":"16ba438f-6853-4870-8a92-2699b82c76f9","type":"library"}]}}}}'
+      string: '{"data":{"attributes":{"name":"Test Package"},"type":"package","relationships":{"script":{"data":{"id":"3a6ce3bf-8600-4791-87cb-5a8491bd8fa0","type":"script"}},"library":{"data":[{"id":"3d1bcfaa-c882-46e4-9812-6900f5871073","type":"library"}]}}}}'
     headers:
       User-Agent:
       - helium-ruby
@@ -125,31 +125,78 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - 'WARNING: ulimit -n is 1024'
+      - RB_GC_GUARD
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
       Content-Type:
       - application/json;charset=utf8
       Date:
-      - Wed, 19 Apr 2017 19:47:34 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Location:
-      - "/v1/package/56d79191-6505-4732-875a-86c981040868"
+      - "/v1/package/23496d06-d5e5-435c-8192-a9ccb192c7ed"
       Server:
       - Warp/3.2.7
       Content-Length:
-      - '442'
+      - '452'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":null},"relationships":{"script":{"data":{"id":"7026db5a-669a-4433-b44b-48fd0092d93d","type":"script"}},"library":{"data":[{"id":"16ba438f-6853-4870-8a92-2699b82c76f9","type":"library"}]},"sensor-package":{"data":[]},"metadata":{"data":{"id":"56d79191-6505-4732-875a-86c981040868","type":"metadata"}}},"id":"56d79191-6505-4732-875a-86c981040868","meta":{"created":"2017-04-19T19:47:34.233521Z"},"type":"package"}}'
+      string: '{"data":{"attributes":{"name":"Test Package"},"relationships":{"script":{"data":{"id":"3a6ce3bf-8600-4791-87cb-5a8491bd8fa0","type":"script"}},"library":{"data":[{"id":"3d1bcfaa-c882-46e4-9812-6900f5871073","type":"library"}]},"sensor-package":{"data":[]},"metadata":{"data":{"id":"23496d06-d5e5-435c-8192-a9ccb192c7ed","type":"metadata"}}},"id":"23496d06-d5e5-435c-8192-a9ccb192c7ed","meta":{"created":"2017-04-25T22:25:36.775372Z"},"type":"package"}}'
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/package
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 - request:
     method: get
-    uri: https://api.helium.com/v1/package/56d79191-6505-4732-875a-86c981040868/script
+    uri: https://api.helium.com/v1/package/23496d06-d5e5-435c-8192-a9ccb192c7ed/script
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - helium-ruby
+      Authorization:
+      - "<API KEY>"
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Cache-Control, Last-Event-ID
+      Access-Control-Allow-Origin:
+      - "*"
+      Airship-Quip:
+      - sharkfed
+      Airship-Trace:
+      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
+      Content-Type:
+      - application/json;charset=utf8
+      Date:
+      - Tue, 25 Apr 2017 22:25:36 GMT
+      Server:
+      - Warp/3.2.7
+      Content-Length:
+      - '414'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[{"id":"23496d06-d5e5-435c-8192-a9ccb192c7ed","type":"package"}]},"metadata":{"data":{"id":"3a6ce3bf-8600-4791-87cb-5a8491bd8fa0","type":"metadata"}}},"id":"3a6ce3bf-8600-4791-87cb-5a8491bd8fa0","meta":{"created":"2017-04-25T22:25:36.629284Z","digest":"106505101da9e8d279dc688ec1a2cda647debda8d0112553885add44ba039391"},"type":"script"}}'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: https://api.helium.com/v1/package/23496d06-d5e5-435c-8192-a9ccb192c7ed/script
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
+- request:
+    method: get
+    uri: https://api.helium.com/v1/package/23496d06-d5e5-435c-8192-a9ccb192c7ed/library
     body:
       encoding: UTF-8
       string: "{}"
@@ -180,54 +227,7 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf8
       Date:
-      - Wed, 19 Apr 2017 19:47:34 GMT
-      Server:
-      - Warp/3.2.7
-      Content-Length:
-      - '414'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[{"id":"56d79191-6505-4732-875a-86c981040868","type":"package"}]},"metadata":{"data":{"id":"7026db5a-669a-4433-b44b-48fd0092d93d","type":"metadata"}}},"id":"7026db5a-669a-4433-b44b-48fd0092d93d","meta":{"created":"2017-04-19T19:47:34.016069Z","digest":"106505101da9e8d279dc688ec1a2cda647debda8d0112553885add44ba039391"},"type":"script"}}'
-    http_version: '1.1'
-    adapter_metadata:
-      effective_url: https://api.helium.com/v1/package/56d79191-6505-4732-875a-86c981040868/script
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
-- request:
-    method: get
-    uri: https://api.helium.com/v1/package/56d79191-6505-4732-875a-86c981040868/library
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      User-Agent:
-      - helium-ruby
-      Authorization:
-      - "<API KEY>"
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      Expect:
-      - ''
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Cache-Control, Last-Event-ID
-      Access-Control-Allow-Origin:
-      - "*"
-      Airship-Quip:
-      - evacuation not done in time
-      Airship-Trace:
-      - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,o16,o17,o18
-      Content-Type:
-      - application/json;charset=utf8
-      Date:
-      - Wed, 19 Apr 2017 19:47:34 GMT
+      - Tue, 25 Apr 2017 22:25:36 GMT
       Server:
       - Warp/3.2.7
       Content-Length:
@@ -236,14 +236,14 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":[{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[{"id":"56d79191-6505-4732-875a-86c981040868","type":"package"}]},"metadata":{"data":{"id":"16ba438f-6853-4870-8a92-2699b82c76f9","type":"metadata"}}},"id":"16ba438f-6853-4870-8a92-2699b82c76f9","meta":{"created":"2017-04-19T19:47:34.160265Z","digest":"500800f8193f61c59a5e1a085971a23a7bc2473529fddf9cdd46b48096f387f3"},"type":"library"}]}'
+      string: '{"data":[{"attributes":{"name":"test.lua"},"relationships":{"package":{"data":[{"id":"23496d06-d5e5-435c-8192-a9ccb192c7ed","type":"package"}]},"metadata":{"data":{"id":"3d1bcfaa-c882-46e4-9812-6900f5871073","type":"metadata"}}},"id":"3d1bcfaa-c882-46e4-9812-6900f5871073","meta":{"created":"2017-04-25T22:25:36.704877Z","digest":"500800f8193f61c59a5e1a085971a23a7bc2473529fddf9cdd46b48096f387f3"},"type":"library"}]}'
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/package/56d79191-6505-4732-875a-86c981040868/library
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
+      effective_url: https://api.helium.com/v1/package/23496d06-d5e5-435c-8192-a9ccb192c7ed/library
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 - request:
     method: delete
-    uri: https://api.helium.com/v1/package/56d79191-6505-4732-875a-86c981040868
+    uri: https://api.helium.com/v1/package/23496d06-d5e5-435c-8192-a9ccb192c7ed
     body:
       encoding: UTF-8
       string: "{}"
@@ -268,11 +268,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - blame me if inappropriate
+      - "$300,000 worth of cows"
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
       Date:
-      - Wed, 19 Apr 2017 19:47:34 GMT
+      - Tue, 25 Apr 2017 22:25:36 GMT
       Server:
       - Warp/3.2.7
       Connection:
@@ -282,11 +282,11 @@ http_interactions:
       string: ''
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/package/56d79191-6505-4732-875a-86c981040868
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
+      effective_url: https://api.helium.com/v1/package/23496d06-d5e5-435c-8192-a9ccb192c7ed
+  recorded_at: Tue, 25 Apr 2017 22:25:37 GMT
 - request:
     method: delete
-    uri: https://api.helium.com/v1/library/16ba438f-6853-4870-8a92-2699b82c76f9
+    uri: https://api.helium.com/v1/library/3d1bcfaa-c882-46e4-9812-6900f5871073
     body:
       encoding: UTF-8
       string: "{}"
@@ -311,11 +311,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - evacuation not done in time
+      - sharkfed
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
       Date:
-      - Wed, 19 Apr 2017 19:47:34 GMT
+      - Tue, 25 Apr 2017 22:25:36 GMT
       Server:
       - Warp/3.2.7
       Connection:
@@ -325,11 +325,11 @@ http_interactions:
       string: ''
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/library/16ba438f-6853-4870-8a92-2699b82c76f9
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
+      effective_url: https://api.helium.com/v1/library/3d1bcfaa-c882-46e4-9812-6900f5871073
+  recorded_at: Tue, 25 Apr 2017 22:25:37 GMT
 - request:
     method: delete
-    uri: https://api.helium.com/v1/script/7026db5a-669a-4433-b44b-48fd0092d93d
+    uri: https://api.helium.com/v1/script/3a6ce3bf-8600-4791-87cb-5a8491bd8fa0
     body:
       encoding: UTF-8
       string: "{}"
@@ -354,11 +354,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - shut it down
+      - sharkfed
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
       Date:
-      - Wed, 19 Apr 2017 19:47:34 GMT
+      - Tue, 25 Apr 2017 22:25:36 GMT
       Server:
       - Warp/3.2.7
       Connection:
@@ -368,6 +368,6 @@ http_interactions:
       string: ''
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/script/7026db5a-669a-4433-b44b-48fd0092d93d
-  recorded_at: Wed, 19 Apr 2017 19:47:34 GMT
+      effective_url: https://api.helium.com/v1/script/3a6ce3bf-8600-4791-87cb-5a8491bd8fa0
+  recorded_at: Tue, 25 Apr 2017 22:25:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/helium_scripts/create_package.yml
+++ b/spec/vcr/helium_scripts/create_package.yml
@@ -27,15 +27,15 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - firm pat on the back
+      - blame me if inappropriate
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
       Content-Type:
       - application/json;charset=utf8
       Date:
-      - Wed, 19 Apr 2017 19:47:29 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Location:
-      - "/v1/script/cba8c14d-fce0-4f95-8ffb-1e97ec32620e"
+      - "/v1/script/0c1d5a71-1b2b-4d80-ae3a-e9772b605bc3"
       Server:
       - Warp/3.2.7
       Content-Length:
@@ -44,11 +44,11 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"script.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"cba8c14d-fce0-4f95-8ffb-1e97ec32620e","type":"metadata"}}},"id":"cba8c14d-fce0-4f95-8ffb-1e97ec32620e","meta":{"created":"2017-04-19T19:47:29.278748Z","digest":"106505101da9e8d279dc688ec1a2cda647debda8d0112553885add44ba039391"},"type":"script"}}'
+      string: '{"data":{"attributes":{"name":"script.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"0c1d5a71-1b2b-4d80-ae3a-e9772b605bc3","type":"metadata"}}},"id":"0c1d5a71-1b2b-4d80-ae3a-e9772b605bc3","meta":{"created":"2017-04-25T22:25:35.827155Z","digest":"106505101da9e8d279dc688ec1a2cda647debda8d0112553885add44ba039391"},"type":"script"}}'
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/script
-  recorded_at: Wed, 19 Apr 2017 19:47:29 GMT
+  recorded_at: Tue, 25 Apr 2017 22:25:35 GMT
 - request:
     method: post
     uri: https://api.helium.com/v1/library
@@ -76,15 +76,15 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - "$300,000 worth of cows"
+      - shut it down
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
       Content-Type:
       - application/json;charset=utf8
       Date:
-      - Wed, 19 Apr 2017 19:47:28 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Location:
-      - "/v1/library/8feb0d24-df1f-415b-832a-025974f45af3"
+      - "/v1/library/73e2278b-5bb9-46ad-9ccd-7f21efc1288f"
       Server:
       - Warp/3.2.7
       Content-Length:
@@ -93,17 +93,17 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"lib.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"8feb0d24-df1f-415b-832a-025974f45af3","type":"metadata"}}},"id":"8feb0d24-df1f-415b-832a-025974f45af3","meta":{"created":"2017-04-19T19:47:29.353145Z","digest":"500800f8193f61c59a5e1a085971a23a7bc2473529fddf9cdd46b48096f387f3"},"type":"library"}}'
+      string: '{"data":{"attributes":{"name":"lib.lua"},"relationships":{"package":{"data":[]},"metadata":{"data":{"id":"73e2278b-5bb9-46ad-9ccd-7f21efc1288f","type":"metadata"}}},"id":"73e2278b-5bb9-46ad-9ccd-7f21efc1288f","meta":{"created":"2017-04-25T22:25:35.901951Z","digest":"500800f8193f61c59a5e1a085971a23a7bc2473529fddf9cdd46b48096f387f3"},"type":"library"}}'
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/library
-  recorded_at: Wed, 19 Apr 2017 19:47:29 GMT
+  recorded_at: Tue, 25 Apr 2017 22:25:35 GMT
 - request:
     method: post
     uri: https://api.helium.com/v1/package
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":"test package"},"type":"package","relationships":{"script":{"data":{"id":"cba8c14d-fce0-4f95-8ffb-1e97ec32620e","type":"script"}},"library":{"data":[{"id":"8feb0d24-df1f-415b-832a-025974f45af3","type":"library"}]}}}}'
+      string: '{"data":{"attributes":{"name":"test package"},"type":"package","relationships":{"script":{"data":{"id":"0c1d5a71-1b2b-4d80-ae3a-e9772b605bc3","type":"script"}},"library":{"data":[{"id":"73e2278b-5bb9-46ad-9ccd-7f21efc1288f","type":"library"}]}}}}'
     headers:
       User-Agent:
       - helium-ruby
@@ -125,31 +125,31 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - shut it down
+      - blame me if inappropriate
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,n16,n11,p11
       Content-Type:
       - application/json;charset=utf8
       Date:
-      - Wed, 19 Apr 2017 19:47:28 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Location:
-      - "/v1/package/d6b1394d-ed30-4256-93da-94a7ec50055d"
+      - "/v1/package/790ca944-32db-49e9-afd9-5e61f724efca"
       Server:
       - Warp/3.2.7
       Content-Length:
-      - '442'
+      - '452'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":{"attributes":{"name":null},"relationships":{"script":{"data":{"id":"cba8c14d-fce0-4f95-8ffb-1e97ec32620e","type":"script"}},"library":{"data":[{"id":"8feb0d24-df1f-415b-832a-025974f45af3","type":"library"}]},"sensor-package":{"data":[]},"metadata":{"data":{"id":"d6b1394d-ed30-4256-93da-94a7ec50055d","type":"metadata"}}},"id":"d6b1394d-ed30-4256-93da-94a7ec50055d","meta":{"created":"2017-04-19T19:47:29.428166Z"},"type":"package"}}'
+      string: '{"data":{"attributes":{"name":"test package"},"relationships":{"script":{"data":{"id":"0c1d5a71-1b2b-4d80-ae3a-e9772b605bc3","type":"script"}},"library":{"data":[{"id":"73e2278b-5bb9-46ad-9ccd-7f21efc1288f","type":"library"}]},"sensor-package":{"data":[]},"metadata":{"data":{"id":"790ca944-32db-49e9-afd9-5e61f724efca","type":"metadata"}}},"id":"790ca944-32db-49e9-afd9-5e61f724efca","meta":{"created":"2017-04-25T22:25:35.979296Z"},"type":"package"}}'
     http_version: '1.1'
     adapter_metadata:
       effective_url: https://api.helium.com/v1/package
-  recorded_at: Wed, 19 Apr 2017 19:47:29 GMT
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 - request:
     method: delete
-    uri: https://api.helium.com/v1/package/d6b1394d-ed30-4256-93da-94a7ec50055d
+    uri: https://api.helium.com/v1/package/790ca944-32db-49e9-afd9-5e61f724efca
     body:
       encoding: UTF-8
       string: "{}"
@@ -178,7 +178,7 @@ http_interactions:
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
       Date:
-      - Wed, 19 Apr 2017 19:47:28 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Server:
       - Warp/3.2.7
       Connection:
@@ -188,11 +188,11 @@ http_interactions:
       string: ''
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/package/d6b1394d-ed30-4256-93da-94a7ec50055d
-  recorded_at: Wed, 19 Apr 2017 19:47:29 GMT
+      effective_url: https://api.helium.com/v1/package/790ca944-32db-49e9-afd9-5e61f724efca
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 - request:
     method: delete
-    uri: https://api.helium.com/v1/script/cba8c14d-fce0-4f95-8ffb-1e97ec32620e
+    uri: https://api.helium.com/v1/script/0c1d5a71-1b2b-4d80-ae3a-e9772b605bc3
     body:
       encoding: UTF-8
       string: "{}"
@@ -217,11 +217,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - 'WARNING: ulimit -n is 1024'
+      - blame me if inappropriate
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
       Date:
-      - Wed, 19 Apr 2017 19:47:28 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Server:
       - Warp/3.2.7
       Connection:
@@ -231,11 +231,11 @@ http_interactions:
       string: ''
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/script/cba8c14d-fce0-4f95-8ffb-1e97ec32620e
-  recorded_at: Wed, 19 Apr 2017 19:47:29 GMT
+      effective_url: https://api.helium.com/v1/script/0c1d5a71-1b2b-4d80-ae3a-e9772b605bc3
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 - request:
     method: delete
-    uri: https://api.helium.com/v1/library/8feb0d24-df1f-415b-832a-025974f45af3
+    uri: https://api.helium.com/v1/library/73e2278b-5bb9-46ad-9ccd-7f21efc1288f
     body:
       encoding: UTF-8
       string: "{}"
@@ -260,11 +260,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Airship-Quip:
-      - firm pat on the back
+      - shut it down
       Airship-Trace:
       - b13,b12,b11,b10,b09,b08,b07,b06,b05,b04,b03,c03,c04,d04,e05,f06,g07,g08,h10,i12,l13,m16,m20,o20
       Date:
-      - Wed, 19 Apr 2017 19:47:29 GMT
+      - Tue, 25 Apr 2017 22:25:35 GMT
       Server:
       - Warp/3.2.7
       Connection:
@@ -274,6 +274,6 @@ http_interactions:
       string: ''
     http_version: '1.1'
     adapter_metadata:
-      effective_url: https://api.helium.com/v1/library/8feb0d24-df1f-415b-832a-025974f45af3
-  recorded_at: Wed, 19 Apr 2017 19:47:29 GMT
+      effective_url: https://api.helium.com/v1/library/73e2278b-5bb9-46ad-9ccd-7f21efc1288f
+  recorded_at: Tue, 25 Apr 2017 22:25:36 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
There was a bug in the API that prevented package resources from being created with names. This has been fixed and deployed, so the helium-ruby tests have been updated accordingly.

No need to release after this is merged.